### PR TITLE
feat: checkbox

### DIFF
--- a/packages/ui-shared/components.d.ts
+++ b/packages/ui-shared/components.d.ts
@@ -9,6 +9,7 @@ export {}
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
     BitMapFilterList: typeof import('./lib/components/BitMapFilterList.vue')['default']
+    Checkbox: typeof import('./lib/components/Checkbox.vue')['default']
     Datepicker: typeof import('./lib/components/Datepicker.vue')['default']
     Dropdown: typeof import('./lib/components/Dropdown.vue')['default']
     DropdownItem: typeof import('./lib/components/DropdownItem.vue')['default']

--- a/packages/ui-shared/lib/components/Checkbox.vue
+++ b/packages/ui-shared/lib/components/Checkbox.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps({
+  modelValue: Boolean,
+  checkboxOnRight: Boolean,
+  sm: Boolean,
+  lg: Boolean
+})
+
+const emits = defineEmits<{
+  (e: 'update:modelValue', value: Boolean)
+}>()
+
+const isChecked = computed({
+  get: () => props.modelValue,
+  set: (value) => emits('update:modelValue', value)
+})
+
+const classesComputed = computed(() => {
+  if (props.sm) return 'w-3 h-3 relative'
+
+  if (props.lg) return 'w-5 h-5 relative'
+
+  return 'w-4 h-4 relative'
+})
+
+const checkboxClassesComputed = computed(() => {
+  if (props.sm)
+    return 'left-1/2 top-0 bottom-0 right-0 -translate-x-[2px] -translate-y-[1px] scale-75'
+
+  if (props.lg)
+    return 'left-1/2 top-0 bottom-0 right-0 -translate-x-1 -translate-y-[2px] scale-75'
+
+  return 'left-1/2 top-0 bottom-0 right-0 -translate-x-1 -translate-y-[2px] scale-75'
+})
+</script>
+
+<template>
+  <label class="flex space-x-2 relative">
+    <slot v-if="!checkboxOnRight" name="checkbox" v-bind="{ isChecked }">
+      <div class="grid place-items-center">
+        <div :class="classesComputed">
+          <div class="absolute inset-0 border-black dark:border-white border">
+            <div
+              v-if="isChecked"
+              class="absolute border-transparent dark:border-r-white dark:border-b-white border-r-black border-b-black border-2 rotate-45"
+              :class="checkboxClassesComputed"
+            />
+          </div>
+        </div>
+      </div>
+    </slot>
+
+    <div class="flex items-center">
+      <slot />
+    </div>
+
+    <slot v-if="checkboxOnRight" name="checkbox" v-bind="{ isChecked }">
+      <div class="grid place-items-center">
+        <div :class="classesComputed">
+          <div class="absolute inset-0 border-black dark:border-white border">
+            <div
+              v-if="isChecked"
+              class="absolute left-1/2 top-0 bottom-0 right-0 border-transparent dark:border-r-white dark:border-b-white border-r-black border-b-black border-2 rotate-45 -translate-x-1 -translate-y-[2px] scale-75"
+            />
+          </div>
+        </div>
+      </div>
+    </slot>
+
+    <input
+      v-model="isChecked"
+      type="checkbox"
+      class="absolute inset-0 opacity-0"
+    />
+  </label>
+</template>

--- a/packages/ui-shared/playground/story/Checkbox.story.vue
+++ b/packages/ui-shared/playground/story/Checkbox.story.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+const checked = ref(false)
+</script>
+
+<template>
+  <Story title="checkbox">
+    <div class="p-2 max-w-lg space-y-4 text-white">
+      <div class="border-b border-white py-2">
+        <BaseCheckbox v-model="checked"> Default Checkbox </BaseCheckbox>
+      </div>
+
+      <div class="border-b border-white py-2">
+        <BaseCheckbox v-model="checked" sm>
+          <span class="text-sm">sm Checkbox</span>
+        </BaseCheckbox>
+      </div>
+
+      <div class="border-b border-white py-2">
+        <BaseCheckbox v-model="checked" lg> lg Checkbox </BaseCheckbox>
+      </div>
+
+      <div class="border-b border-white py-2 flex justify-end">
+        <BaseCheckbox v-model="checked" checkbox-on-right>
+          Right Side Checkbox
+        </BaseCheckbox>
+      </div>
+
+      <div class="border-b border-white py-2">
+        <BaseCheckbox v-model="checked">
+          <template #checkbox="{ isChecked }">
+            <div class="grid place-items-center w-6">
+              <div
+                class="h-4 border-2 border-white transition-all duration-300"
+                :class="[
+                  isChecked
+                    ? 'border-l-transparent border-t-transparent rotate-45 w-2'
+                    : 'w-4'
+                ]"
+              ></div>
+            </div>
+          </template>
+
+          Custom Checkbox
+        </BaseCheckbox>
+      </div>
+
+      <div>
+        <BaseCheckbox v-model="checked" />
+      </div>
+    </div>
+  </Story>
+</template>


### PR DESCRIPTION
This PR Adds a Checkbox component to UI Shared..

- The `input` tag is inside the `label` tag, so there is no need for UID (`:id='uid'`).
- ability to place the checkbox on right through props.
- headless ( if you add a template with `#checkbox` you can add your own design for the checkbox)
- 

![image](https://user-images.githubusercontent.com/56976418/232645502-0ba54095-c319-49c6-8247-c17c0359d84a.png)

![image](https://user-images.githubusercontent.com/56976418/232645521-092dccad-d243-40da-b330-4d5bbbfe8076.png)
