### PR TITLE
chore: add value to paste event

### DIFF
--- a/packages/ui-shared/lib/components/Input.vue
+++ b/packages/ui-shared/lib/components/Input.vue
@@ -11,7 +11,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits<{
-  pasted: []
+  pasted: [value: string]
   'input:changed': [value: string]
   'update:modelValue': [state: string]
 
@@ -34,7 +34,7 @@ function onPaste(payload: ClipboardEvent) {
 
     emit('update:modelValue', updatedValue)
     emit('input:changed', updatedValue)
-    emit('pasted')
+    emit('pasted', updatedValue)
 
     // Legacy
     emit('paste')


### PR DESCRIPTION
## Changes
- added `value` parameter to the `pasted` event for `Input.vue` so that way we can use it to update a model value instantly on paste even though the UI component may have a debounce function for the `update:modelValue` event
- should have no side effects across products since they would not currently be currently listening for a `pasted` event parameter
- opted to not add the `value` parameter to the legacy `paste` event since is deprecated