### PR TITLE
chore: tooltip attrs

### DIFF
--- a/packages/ui-shared/lib/components/Tooltip.vue
+++ b/packages/ui-shared/lib/components/Tooltip.vue
@@ -3,7 +3,7 @@ import { Tooltip } from 'floating-vue'
 </script>
 
 <template>
-  <Tooltip>
+  <Tooltip v-bind="$attrs">
     <div>
       <slot />
     </div>

--- a/packages/ui-shared/playground/story/Tooltip.story.vue
+++ b/packages/ui-shared/playground/story/Tooltip.story.vue
@@ -8,6 +8,16 @@
           <div class="max-w-[240px] p-2 text-sm">Random tooltip string</div>
         </template>
       </BaseTooltip>
+
+      <BaseTooltip class="inline-block" v-bind="{ delay: { hide: 2000 } }">
+        <BaseIcon name="circle-info" class="min-w-4 w-4 text-gray-600" />
+
+        <template #content>
+          <div class="max-w-[240px] p-2 text-sm">
+            Random tooltip string With Hide Delay
+          </div>
+        </template>
+      </BaseTooltip>
     </div>
   </Story>
 </template>


### PR DESCRIPTION
## In This PR:
- we can now pass the attrs so we can set the hide delay for example.
- this is if we need to click a link inside a tooltip. (Click here for adding token metadata)