### PR TITLE
chore: add ts-types package

### DIFF
--- a/layer/package.json
+++ b/layer/package.json
@@ -12,6 +12,7 @@
     "@injectivelabs/utils": "1.14.11-beta.3",
     "@injectivelabs/networks": "1.14.11-beta.4",
     "@injectivelabs/sdk-ts": "1.14.11-beta.27",
+    "@injectivelabs/ts-types": "1.14.11-beta.1",
     "@injectivelabs/sdk-ui-ts": "1.14.11-beta.39",
     "@injectivelabs/token-metadata": "1.14.11-beta.20",
     "@injectivelabs/wallet-ts": "1.14.11-beta.35",

--- a/layer/yarn.lock
+++ b/layer/yarn.lock
@@ -1705,7 +1705,7 @@
     link-module-alias "^1.2.0"
     shx "^0.3.2"
 
-"@injectivelabs/ts-types@^1.14.11-beta.1":
+"@injectivelabs/ts-types@1.14.11-beta.1", "@injectivelabs/ts-types@^1.14.11-beta.1":
   version "1.14.11-beta.1"
   resolved "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.11-beta.1.tgz#029699ae5c63df892fc7a62799947a6511a75f73"
   integrity sha512-vePKrNWmQDW0+goKqhsWQgTLpMgo/GjL0PFtUha+qecFnKE8Bl+I47MGPk318CGY3wu5m6Ah4gBWEIYAei4VLw==


### PR DESCRIPTION
## Changes
- added `@injectivelabs/ts-types` package to layers because we import a few files from `ts-types` in layers, and I noticed that it would use the `@injectivelabs/ts-types` version in `/node_modules` instead of the one in `/layer/node_modules/`, unless you add it to the package.json 