### PR TITLE
Fix: broken Twitter Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 Reach out to us at one of the following places!
 
 - Website at <a href="https://injective.com" target="_blank">`injective.com`</a>
-- Twitter at <a href="https://twitter.com/Injective_" target="_blank">`@Injective`</a>
+- Twitter at <a href="https://twitter.com/injective" target="_blank">`@Injective`</a>
 - Discord at <a href="https://discord.com/invite/NK4qdbv" target="_blank">`Discord`</a>
 - Telegram at <a href="https://t.me/joininjective" target="_blank">`Telegram`</a>
 


### PR DESCRIPTION
fixed broken twitter link in README 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Twitter link in the README file to the new URL: `https://twitter.com/injective`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->