### PR TITLE
fix: imask num input override paste ux

### DIFF
--- a/layer/components/NumInput.vue
+++ b/layer/components/NumInput.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useIMask } from 'vue-imask'
 import type { FactoryOpts } from 'imask'
+import { BigNumberInBase } from '@injectivelabs/utils'
 
 const props = defineProps({
   isAutofix: Boolean,
@@ -70,6 +71,20 @@ const { typed, el } = useIMask(
   }
 )
 
+function onPaste(e: ClipboardEvent) {
+  if (!e.clipboardData) {
+    return
+  }
+
+  e.preventDefault()
+
+  const text = e.clipboardData.getData('text/plain')
+  const value = new BigNumberInBase(text).toFixed(props.maxDecimals)
+
+  typed.value = value
+  emit('update:modelValue', value)
+}
+
 watch(
   () => props.modelValue,
   async (value) => {
@@ -80,5 +95,11 @@ watch(
 </script>
 
 <template>
-  <input ref="el" type="text" class="input-base" v-bind="$attrs" />
+  <input
+    ref="el"
+    type="text"
+    class="input-base"
+    v-bind="$attrs"
+    @paste="onPaste"
+  />
 </template>

--- a/layer/components/NumInput.vue
+++ b/layer/components/NumInput.vue
@@ -78,11 +78,10 @@ function onPaste(e: ClipboardEvent) {
 
   e.preventDefault()
 
-  const text = e.clipboardData.getData('text/plain')
+  const text = e.clipboardData.getData('text/plain').replaceAll(',', '')
   const value = new BigNumberInBase(text).toFixed(props.maxDecimals)
 
   typed.value = value
-  emit('update:modelValue', value)
 }
 
 watch(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced number input component to handle paste events, converting pasted text to a specific format automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->