### PR TITLE
chore: add xion to testnet bridge

### DIFF
--- a/layer/data/bridge.ts
+++ b/layer/data/bridge.ts
@@ -241,6 +241,15 @@ export const cosmosTestnetChannels: Record<string, CosmosChannel> = {
     bToAChannelId: 'channel-1',
     bToAClientId: '07-tendermint-1',
     port: 'transfer'
+  },
+  [Network.Xion]: {
+    aChainId: CosmosChainId[Network.Xion],
+    bChainId: CosmosChainId[Network.Injective],
+    aToBChannelId: 'channel-33',
+    aToBClientId: '07-tendermint-119',
+    bToAChannelId: 'channel-487',
+    bToAClientId: '07-tendermint-239',
+    port: 'transfer'
   }
 }
 

--- a/layer/data/bridge.ts
+++ b/layer/data/bridge.ts
@@ -22,6 +22,8 @@ export const CosmosChainId = {
   [Network.Andromeda]: 'andromeda-1',
   [Network.Saga]: 'ssc-1',
   [Network.Fetch]: 'fetchhub-4',
+  [Network.XionTestnet]: 'xion-testnet-1',
+
 
   // networks below are disabled
   [Network.Canto]: 'canto_7700-1',
@@ -242,13 +244,13 @@ export const cosmosTestnetChannels: Record<string, CosmosChannel> = {
     bToAClientId: '07-tendermint-1',
     port: 'transfer'
   },
-  [Network.Xion]: {
-    aChainId: CosmosChainId[Network.Xion],
+  [Network.XionTestnet]: {
+    aChainId: CosmosChainId[Network.XionTestnet],
     bChainId: CosmosChainId[Network.Injective],
-    aToBChannelId: 'channel-33',
-    aToBClientId: '07-tendermint-119',
-    bToAChannelId: 'channel-487',
-    bToAClientId: '07-tendermint-239',
+    aToBChannelId: 'channel-487',
+    aToBClientId: '',
+    bToAChannelId: 'channel-489',
+    bToAClientId: '',
     port: 'transfer'
   }
 }

--- a/layer/data/ibc.ts
+++ b/layer/data/ibc.ts
@@ -20,6 +20,7 @@ export const canonicalChannelsToChainList = [
   { channelId: 'channel-54', chainA: 'Kujira', chainB: 'Injective' },
   { channelId: 'channel-13', chainA: 'Andromeda', chainB: 'Injective' },
   { channelId: 'channel-25', chainA: 'Saga', chainB: 'Injective' },
+  { channelId: 'channel-489', chainA: 'Xion', chainB: 'Injective' }
   { channelId: 'channel-33', chainA: 'fetchhub-4', chainB: 'Injective' },
   { channelId: 'channel-1', chainA: 'Injective', chainB: 'CosmosHub' },
   { channelId: 'channel-83', chainA: 'Injective', chainB: 'Evmos' },
@@ -48,7 +49,8 @@ export const canonicalChannelsToChainList = [
   { channelId: 'channel-183', chainA: 'Injective', chainB: 'Gateway' },
   { channelId: 'channel-213', chainA: 'Injective', chainB: 'Andromeda' },
   { channelId: 'channel-261', chainA: 'Injective', chainB: 'Saga' },
-  { channelId: 'channel-283', chainA: 'Injective', chainB: 'fetchhub-4' }
+  { channelId: 'channel-283', chainA: 'Injective', chainB: 'fetchhub-4' },
+  { channelId: 'channel-487', chainA: 'Injective', chainB: 'Xion' }
 ]
 
 export const canonicalChannelIds = [
@@ -82,5 +84,6 @@ export const canonicalChannelIds = [
   'channel-183',
   'channel-213',
   'channel-261',
-  'channel-283'
+  'channel-283',
+  'channel-487'
 ]

--- a/layer/data/ibc.ts
+++ b/layer/data/ibc.ts
@@ -20,7 +20,6 @@ export const canonicalChannelsToChainList = [
   { channelId: 'channel-54', chainA: 'Kujira', chainB: 'Injective' },
   { channelId: 'channel-13', chainA: 'Andromeda', chainB: 'Injective' },
   { channelId: 'channel-25', chainA: 'Saga', chainB: 'Injective' },
-  { channelId: 'channel-489', chainA: 'Xion', chainB: 'Injective' }
   { channelId: 'channel-33', chainA: 'fetchhub-4', chainB: 'Injective' },
   { channelId: 'channel-1', chainA: 'Injective', chainB: 'CosmosHub' },
   { channelId: 'channel-83', chainA: 'Injective', chainB: 'Evmos' },
@@ -50,7 +49,6 @@ export const canonicalChannelsToChainList = [
   { channelId: 'channel-213', chainA: 'Injective', chainB: 'Andromeda' },
   { channelId: 'channel-261', chainA: 'Injective', chainB: 'Saga' },
   { channelId: 'channel-283', chainA: 'Injective', chainB: 'fetchhub-4' },
-  { channelId: 'channel-487', chainA: 'Injective', chainB: 'Xion' }
 ]
 
 export const canonicalChannelIds = [
@@ -85,5 +83,4 @@ export const canonicalChannelIds = [
   'channel-213',
   'channel-261',
   'channel-283',
-  'channel-487'
 ]

--- a/layer/types/bridge.ts
+++ b/layer/types/bridge.ts
@@ -40,4 +40,5 @@ export enum Network {
   CosmosHubTestnet = 'cosmosHub-testnet',
   Andromeda = 'andromeda',
   Saga = 'saga',
+  Xion = 'xion'
 }

--- a/layer/types/bridge.ts
+++ b/layer/types/bridge.ts
@@ -40,5 +40,5 @@ export enum Network {
   CosmosHubTestnet = 'cosmosHub-testnet',
   Andromeda = 'andromeda',
   Saga = 'saga',
-  Xion = 'xion'
+  XionTestnet = 'xion-testnet'
 }

--- a/layer/utils/network.ts
+++ b/layer/utils/network.ts
@@ -107,6 +107,8 @@ export const getNetworkFromAddress = (address: string): Network => {
       return Network.Kujira
     case address.startsWith('saga'):
       return Network.Saga
+    case address.startsWith('xion'):
+      return Network.Xion
     default:
       return Network.Injective
   }
@@ -164,6 +166,8 @@ const getMainnetNetworkExplorerUrl = (network: Network): string => {
       return 'https://www.mintscan.io/saga'
     case Network.Fetch:
       return 'https://www.mintscan.io/fetchai'
+    case Network.Xion:
+      return 'https://testnet.xion.explorers.guru'
     case Network.Injective:
       return 'https://explorer.injective.network'
     default:

--- a/layer/utils/network.ts
+++ b/layer/utils/network.ts
@@ -108,7 +108,7 @@ export const getNetworkFromAddress = (address: string): Network => {
     case address.startsWith('saga'):
       return Network.Saga
     case address.startsWith('xion'):
-      return Network.Xion
+      return Network.XionTestnet
     default:
       return Network.Injective
   }
@@ -166,8 +166,6 @@ const getMainnetNetworkExplorerUrl = (network: Network): string => {
       return 'https://www.mintscan.io/saga'
     case Network.Fetch:
       return 'https://www.mintscan.io/fetchai'
-    case Network.Xion:
-      return 'https://testnet.xion.explorers.guru'
     case Network.Injective:
       return 'https://explorer.injective.network'
     default:
@@ -201,6 +199,8 @@ const getTestNetworkExplorerUrl = (network: Network): string => {
       return 'https://www.mintscan.io/persistence-testnet'
     case Network.Osmosis:
       return 'https://www.mintscan.io/osmosis-testnet'
+    case Network.XionTestnet:
+      return 'https://explorer.burnt.com/xion-testnet-1'
     case Network.Kava:
       return 'https://www.mintscan.io/kava-testnet'
     case Network.Noble:


### PR DESCRIPTION
add xion to testnet bridge - hope it is just testnet and not mainnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added support for the Xion and XionTestnet networks, enhancing interoperability within the Cosmos ecosystem.
	- Introduced new channel mappings between Xion and Injective, allowing for improved blockchain communication.
	- Expanded the available network options in the system to include both Xion and XionTestnet.

- **Bug Fixes**
	- Enhanced the handling of network addresses to include recognition of Xion addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->