### PR TITLE
chore: add xion to bridge

### DIFF
--- a/layer/data/bridge.ts
+++ b/layer/data/bridge.ts
@@ -27,6 +27,7 @@ export const CosmosChainId = {
   [Network.Mantra]: 'mantra-1',
   [Network.WormholeGeneric]: 'wormchain',
   [Network.Neutron]: 'neutron-1',
+  [Network.Xion]: 'xion-mainnet-1',
 
   // networks below are disabled
   [Network.Canto]: 'canto_7700-1',
@@ -207,6 +208,15 @@ export const cosmoMainnetChannel: Record<string, CosmosChannel> = {
     aToBClientId: '07-tendermint-2',
     bToAChannelId: 'channel-363',
     bToAClientId: '07-tendermint-275',
+    port: 'transfer'
+  },
+  [Network.Xion]: {
+    aChainId: CosmosChainId[Network.Xion],
+    bChainId: CosmosChainId[Network.Injective],
+    aToBChannelId: 'channel-4',
+    aToBClientId: '07-tendermint-4',
+    bToAChannelId: 'channel-387',
+    bToAClientId: '07-tendermint-279',
     port: 'transfer'
   }
   // networks below are disabled

--- a/layer/data/ibc.ts
+++ b/layer/data/ibc.ts
@@ -22,6 +22,7 @@ export const canonicalChannelsToChainList = [
   { channelId: 'channel-25', chainA: 'Saga', chainB: 'Injective' },
   { channelId: 'channel-33', chainA: 'fetchhub-4', chainB: 'Injective' },
   { channelId: 'channel-2', chainA: 'mantrachain', chainB: 'Injective' },
+  { channelId: 'channel-4', chainA: 'xion-mainnet-1', chainB: 'Injective' },
   { channelId: 'channel-1', chainA: 'Injective', chainB: 'CosmosHub' },
   { channelId: 'channel-83', chainA: 'Injective', chainB: 'Evmos' },
   { channelId: 'channel-8', chainA: 'Injective', chainB: 'Osmosis' },
@@ -50,7 +51,8 @@ export const canonicalChannelsToChainList = [
   { channelId: 'channel-213', chainA: 'Injective', chainB: 'Andromeda' },
   { channelId: 'channel-261', chainA: 'Injective', chainB: 'Saga' },
   { channelId: 'channel-283', chainA: 'Injective', chainB: 'fetchhub-4' },
-  { channelId: 'channel-363', chainA: 'Injective', chainB: 'mantrachain' }
+  { channelId: 'channel-363', chainA: 'Injective', chainB: 'mantrachain' },
+  { channelId: 'channel-387', chainA: 'Injective', chainB: 'xion-mainnet-1' }
 ]
 
 export const canonicalChannelIds = [
@@ -85,5 +87,6 @@ export const canonicalChannelIds = [
   'channel-213',
   'channel-261',
   'channel-283',
-  'channel-363'
+  'channel-363',
+  'channel-387'
 ]

--- a/layer/types/bridge.ts
+++ b/layer/types/bridge.ts
@@ -45,6 +45,7 @@ export enum Network {
   WormholeGeneric = 'wormhole-generic',
   XionTestnet = 'xion-testnet',
   EvmosTestnet = 'evmos-testnet',
+  Xion = 'xion-mainnet-1',
   InjectiveDevnet = 'injective-devnet',
   InjectiveTestnet = 'injective-testnet'
 }

--- a/layer/utils/network.ts
+++ b/layer/utils/network.ts
@@ -113,6 +113,8 @@ export const getNetworkFromAddress = (address: string): Network => {
       return Network.Fetch
     case address.startsWith('mantra'):
       return Network.Mantra
+    case address.startsWith('xion'):
+      return Network.Xion
     default:
       return Network.Injective
   }
@@ -172,6 +174,8 @@ const getMainnetNetworkExplorerUrl = (network: Network): string => {
       return 'https://www.mintscan.io/fetchai'
     case Network.Mantra:
       return 'https://www.mintscan.io/mantra'
+    case Network.Xion:
+      return 'https://www.mintscan.io/xion'
     case Network.Injective:
       return 'https://explorer.injective.network'
     default:


### PR DESCRIPTION
add xion to bridge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for the `Xion` network, including new network mappings and channel configurations.
	- Added functionality to recognize addresses starting with 'xion' and provide a dedicated network explorer URL.

- **Bug Fixes**
	- Enhanced the address recognition logic to correctly identify `Network.Xion`.

- **Documentation**
	- Updated relevant entries to reflect the new `Xion` network in the network-related constants and enums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->