### PR TITLE
chore: rwa nuxt cache

### DIFF
--- a/layer/services/pythClient.ts
+++ b/layer/services/pythClient.ts
@@ -1,13 +1,16 @@
 /* eslint-disable camelcase, no-console */
 import { HttpRestClient } from '@injectivelabs/utils'
 
-const PYTH_SERVICE_URL = 'https://benchmarks.pyth.network/v1/'
+// const PYTH_SERVICE_URL = 'https://benchmarks.pyth.network/v1/'
+
+const NUXT_CACHE_PYTH_SERVICE_URL =
+  'https://injective-nuxt-api-staging.vercel.app/api/v1/'
 
 export class PythService {
   private restClient: HttpRestClient
 
   constructor() {
-    this.restClient = new HttpRestClient(PYTH_SERVICE_URL)
+    this.restClient = new HttpRestClient(NUXT_CACHE_PYTH_SERVICE_URL)
   }
 
   public fetchRwaMarketOpenNoThrow = async (pythId: string) => {


### PR DESCRIPTION
## NOTE:
### Currently it uses the STAGING nuxt api, we need to deploy the new api to the master branch on vercel and change the pyth url before deploying this.