### PR TITLE
Feat/amount formatter

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  ...require('@injectivelabs/prettier-config')
-}

--- a/layer/.prettierrc.js
+++ b/layer/.prettierrc.js
@@ -1,7 +1,0 @@
-module.exports = {
-  semi: false,
-  printWidth: 80,
-  singleQuote: true,
-  endOfLine: 'auto',
-  trailingComma: 'none'
-}

--- a/layer/components/Amount/Display.vue
+++ b/layer/components/Amount/Display.vue
@@ -74,7 +74,10 @@ const subscriptedAmount = computed(() => {
     }
   }
 
-  if (nOfZeros > props.subscriptThresholdDecimals) {
+  if (
+    nOfZeros > props.subscriptThresholdDecimals ||
+    nOfZeros > props.decimals
+  ) {
     const subscriptAmount = new BigNumberInBase(decimalPart.replace(/^0+/, ""))
       .toFixed(0)
       .slice(0, props.subscriptDecimals);

--- a/layer/components/Amount/Display.vue
+++ b/layer/components/Amount/Display.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { BigNumberInBase } from "@injectivelabs/utils";
+
+const props = withDefaults(
+  defineProps<{
+    amount: string | number | BigNumberInBase;
+    decimals?: number;
+    useSubscript?: boolean;
+    useAbbreviation?: boolean;
+    abbreviationThreshold?: number;
+    noTrailingZeros?: boolean;
+    subscriptThresholdDecimals?: number;
+    subscriptDecimals?: number;
+  }>(),
+  {
+    decimals: 6,
+    useSubscript: false,
+    useAbbreviation: false,
+    abbreviationThreshold: 1_000_000,
+    noTrailingZeros: false,
+    subscriptThresholdDecimals: 4,
+    subscriptDecimals: 4,
+  },
+);
+
+function abbreviateNumber(num: number, decimals: number = 2): string {
+  const suffixes = ["", "K", "M", "B", "T", "Q", "R", "S", "D", "N"];
+  const tier = (Math.log10(Math.abs(num)) / 3) | 0;
+  const suffix = suffixes[tier];
+  const scale = Math.pow(10, tier * 3);
+
+  const scaled = num / scale;
+  return scaled.toFixed(decimals) + (suffix || "");
+}
+
+const abbreviatedAmount = computed(() => {
+  const amount = new BigNumberInBase(props.amount || 0);
+
+  const nIsBiggerThanThreshold = amount.gte(props.abbreviationThreshold);
+
+  const minDecimalThreshold = new BigNumberInBase(1).div(
+    Math.pow(10, props.decimals),
+  );
+
+  const nIsLowerThanDecimalThreshold = amount.lt(minDecimalThreshold);
+
+  if (props.useAbbreviation && nIsBiggerThanThreshold) {
+    return "~" + abbreviateNumber(Number(props.amount || 0));
+  }
+
+  if (props.useAbbreviation && nIsLowerThanDecimalThreshold && amount.gt(0)) {
+    return "<" + minDecimalThreshold.toFormat();
+  }
+
+  return false;
+});
+
+const subscriptedAmount = computed(() => {
+  const [integerPart, decimalPart] = new BigNumberInBase(props.amount || 0)
+    .toFixed()
+    .split(".");
+
+  if (!decimalPart || !props.useSubscript) {
+    return false;
+  }
+
+  let nOfZeros = 0;
+
+  for (let i = 0; i < decimalPart.length; i++) {
+    if (decimalPart[i] === "0") {
+      nOfZeros++;
+    } else {
+      break;
+    }
+  }
+
+  if (nOfZeros > props.subscriptThresholdDecimals) {
+    const subscriptAmount = new BigNumberInBase(decimalPart.replace(/^0+/, ""))
+      .toFixed(0)
+      .slice(0, props.subscriptDecimals);
+
+    const integerAmount = new BigNumberInBase(integerPart).toFormat(0);
+
+    return integerAmount + ".0<sub>" + nOfZeros + "</sub>" + subscriptAmount;
+  }
+
+  return false;
+});
+
+const formattedAmount = computed(() => {
+  const amount = new BigNumberInBase(props.amount || 0);
+
+  if (props.noTrailingZeros) {
+    return amount.toFormat(props.decimals).replace(/\.?0+$/, "");
+  }
+
+  const formattedAmount = amount.toFormat(props.decimals);
+
+  return formattedAmount;
+});
+</script>
+<template>
+  <span v-if="abbreviatedAmount">{{ abbreviatedAmount }}</span>
+  <span v-else-if="subscriptedAmount" v-html="subscriptedAmount"></span>
+  <span v-else>{{ formattedAmount }}</span>
+</template>

--- a/layer/components/Amount/Formatted.vue
+++ b/layer/components/Amount/Formatted.vue
@@ -1,20 +1,27 @@
 <script setup lang="ts">
 import { BigNumberInBase } from "@injectivelabs/utils";
+import { DEFAULT_ABBREVIATION_THRESHOLD } from "../../utils/constant";
 
 const props = withDefaults(
   defineProps<{
-    amount: string | number | BigNumberInBase;
     decimals?: number;
+    useSubscript?: boolean;
     noTrailingZeros?: boolean;
+    abbreviationThreshold?: number;
+    amount: string | number | BigNumberInBase;
   }>(),
   {
-    decimals: 6,
+    decimals: 8,
     noTrailingZeros: true,
+    abbreviationThreshold: DEFAULT_ABBREVIATION_THRESHOLD,
   },
 );
 
 const decimals = computed(() => {
-  if (new BigNumberInBase(props.amount || 0).gt(1_000_000)) {
+  if (
+    !!props.abbreviationThreshold &&
+    new BigNumberInBase(props.amount || 0).gt(props.abbreviationThreshold)
+  ) {
     return 2;
   }
 
@@ -27,8 +34,9 @@ const decimals = computed(() => {
     v-bind="{
       amount,
       decimals,
-      useSubscript: true,
+      useSubscript,
       noTrailingZeros,
+      abbreviationThreshold,
     }"
   />
 </template>

--- a/layer/components/Amount/Formatted.vue
+++ b/layer/components/Amount/Formatted.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { BigNumberInBase } from "@injectivelabs/utils";
+
+const props = withDefaults(
+  defineProps<{
+    amount: string | number | BigNumberInBase;
+    decimals?: number;
+    noTrailingZeros?: boolean;
+  }>(),
+  {
+    decimals: 6,
+    noTrailingZeros: true,
+  },
+);
+
+const decimals = computed(() => {
+  if (new BigNumberInBase(props.amount || 0).gt(1_000_000)) {
+    return 2;
+  }
+
+  return props.decimals;
+});
+</script>
+
+<template>
+  <SharedAmountDisplay
+    v-bind="{
+      amount,
+      decimals,
+      useSubscript: true,
+      noTrailingZeros,
+    }"
+  />
+</template>

--- a/layer/components/Amount/UsdDisplay.vue
+++ b/layer/components/Amount/UsdDisplay.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import type { BigNumberInBase } from "@injectivelabs/utils";
+import { DEFAULT_ABBREVIATION_THRESHOLD } from "../../utils/constant";
 
 withDefaults(
   defineProps<{
-    amount: string | number | BigNumberInBase;
     showSign?: boolean;
+    abbreviationThreshold?: number;
+    amount: string | number | BigNumberInBase;
   }>(),
   {
     showSign: true,
+    abbreviationThreshold: DEFAULT_ABBREVIATION_THRESHOLD,
   },
 );
 </script>
@@ -15,6 +18,12 @@ withDefaults(
 <template>
   <span>
     <span v-if="showSign">$ </span>
-    <SharedAmountDisplay :amount="amount" :decimals="2" use-abbreviation />
+    <SharedAmountDisplay
+      v-bind="{
+        amount,
+        decimals: 2,
+        abbreviationThreshold,
+      }"
+    />
   </span>
 </template>

--- a/layer/components/Amount/UsdDisplay.vue
+++ b/layer/components/Amount/UsdDisplay.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import type { BigNumberInBase } from "@injectivelabs/utils";
+
+withDefaults(
+  defineProps<{
+    amount: string | number | BigNumberInBase;
+    showSign?: boolean;
+  }>(),
+  {
+    showSign: true,
+  },
+);
+</script>
+
+<template>
+  <span>
+    <span v-if="showSign">$ </span>
+    <SharedAmountDisplay :amount="amount" :decimals="2" use-abbreviation />
+  </span>
+</template>

--- a/layer/composables/useSharedBigNumberFormatted.ts
+++ b/layer/composables/useSharedBigNumberFormatted.ts
@@ -3,6 +3,7 @@ import {
   BigNumberInBase,
   getExactDecimalsFromNumber
 } from '@injectivelabs/utils'
+import { abbreviateNumber } from '../utils/helper'
 
 const ZERO_IN_BASE = new BigNumberInBase(0)
 const DEFAULT_DECIMAL_PLACES = 2
@@ -17,40 +18,6 @@ const getFormattedZeroValue = (decimalPlaces: number) => {
   }
 
   return '0.0'
-}
-
-const unAbbreviateNumber = (value: string): BigNumberInBase | undefined => {
-  const units = {
-    K: Number(`1${'0'.repeat(3)}`),
-    M: Number(`1${'0'.repeat(6)}`),
-    B: Number(`1${'0'.repeat(9)}`),
-    T: Number(`1${'0'.repeat(12)}`)
-  } as Record<string, number>
-
-  const unit = value.at(-1)
-
-  if (!unit || !units[unit]) {
-    return
-  }
-
-  const formattedValue = value.replaceAll(',', '').slice(0, -1)
-
-  return new BigNumberInBase(formattedValue).multipliedBy(units[unit])
-}
-
-const abbreviateNumber = (number: number) => {
-  const abbreviatedValue = new Intl.NumberFormat('en-US', {
-    notation: 'compact',
-    compactDisplay: 'short'
-  }).format(number)
-
-  const abbreviatedValueMatchesInput = new BigNumberInBase(number).eq(
-    unAbbreviateNumber(abbreviatedValue) || '0'
-  )
-
-  return abbreviatedValueMatchesInput
-    ? abbreviatedValue
-    : `≈${abbreviatedValue}`
 }
 
 const getNumberMinimalDecimals = (

--- a/layer/nuxt.config.ts
+++ b/layer/nuxt.config.ts
@@ -1,12 +1,12 @@
-import { vite } from './nuxt-config'
-import { createResolver } from '@nuxt/kit'
-import bugsnag from './nuxt-config/bugsnag'
-import { defineNuxtConfig } from 'nuxt/config'
-import { vitePlugins } from './nuxt-config/vite'
+import { vite } from "./nuxt-config";
+import { createResolver } from "@nuxt/kit";
+import bugsnag from "./nuxt-config/bugsnag";
+import { defineNuxtConfig } from "nuxt/config";
+import { vitePlugins } from "./nuxt-config/vite";
 
-const isProduction = process.env.NODE_ENV === 'production'
+const isProduction = process.env.NODE_ENV === "production";
 
-const { resolve } = createResolver(import.meta.url)
+const { resolve } = createResolver(import.meta.url);
 
 export default defineNuxtConfig({
   vite,
@@ -14,36 +14,36 @@ export default defineNuxtConfig({
   plugins: vitePlugins,
   devtools: { enabled: true },
 
-  alias: { '@shared': resolve('./') },
+  alias: { "@shared": resolve("./") },
 
   typescript: {
-    typeCheck: 'build'
+    typeCheck: "build",
   },
 
   pinia: {
-    autoImports: ['defineStore']
+    autoImports: ["defineStore"],
   },
 
-  ignore: isProduction ? ['pages/sandbox.vue'] : [],
+  ignore: isProduction ? ["pages/sandbox.vue", "pages/playground.vue"] : [],
 
   sourcemap: {
     client: true,
-    server: false
+    server: false,
   },
 
-  components: [{ prefix: 'Shared', path: resolve('./components') }],
+  components: [{ prefix: "Shared", path: resolve("./components") }],
 
   imports: {
-    dirs: ['composables/**', 'store/**', 'store/**/index.ts']
+    dirs: ["composables/**", "store/**", "store/**/index.ts"],
   },
 
   modules: [
-    '@pinia/nuxt',
-    '@vueuse/nuxt',
-    '@nuxtjs/i18n',
-    '@nuxt/eslint',
-    '@nuxt/devtools',
-    'nuxt-vitalizer',
-    '@injectivelabs/nuxt-bugsnag'
-  ]
-})
+    "@pinia/nuxt",
+    "@vueuse/nuxt",
+    "@nuxtjs/i18n",
+    "@nuxt/eslint",
+    "@nuxt/devtools",
+    "nuxt-vitalizer",
+    "@injectivelabs/nuxt-bugsnag",
+  ],
+});

--- a/layer/pages/playground.vue
+++ b/layer/pages/playground.vue
@@ -10,6 +10,7 @@ const values = reactive({
 const testNumbers = [
   "0.0000001",
   "0.01",
+  "1.1",
   "1000",
   "1000000",
   "1000000000.123",
@@ -65,6 +66,30 @@ const testNumbers = [
         </div>
       </UCard>
     </div>
+
+    <UCard class="mt-5">
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <UCard class="flex flex-col">
+          <div class="flex-1 h-full">
+            <p class="text-lg font-bold">Usd Amount</p>
+          </div>
+          <SharedAmountUsdDisplay :amount="values.amount" />
+        </UCard>
+
+        <UCard class="flex flex-col">
+          <div class="flex-1">
+            <p class="text-lg font-bold">Amount</p>
+            <p class="text-xs text-gray-500">
+              (with no trailing zeros & we dont show decimals if the number is
+              bigger than 1M)
+            </p>
+          </div>
+          <div class="mt-2">
+            <SharedAmountFormatted :amount="values.amount" /> INJ
+          </div>
+        </UCard>
+      </div>
+    </UCard>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-5 mt-5">
       <template

--- a/layer/pages/playground.vue
+++ b/layer/pages/playground.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+const values = reactive({
+  amount: "1",
+  decimals: 6,
+  abbreviateThreshold: 1000000,
+  subscriptThresholdDecimals: 4,
+  subscriptDecimals: 4,
+});
+
+const testNumbers = [
+  "0.0000001",
+  "0.01",
+  "1000",
+  "1000000",
+  "1000000000.123",
+  "1000.000000000123",
+  "1000.123",
+  "1580000.123",
+  "1230000000.123",
+
+  "12",
+  "12.34",
+  "12.12345",
+  "1234.12",
+  "1234.12345",
+];
+</script>
+
+<template>
+  <div class="p-5">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-5">
+      <UCard>
+        <div>
+          <p>Amount:</p>
+          <UInput v-model="values.amount" />
+        </div>
+        <div>
+          <p>Decimals:</p>
+          <UInput v-model="values.decimals" type="number" />
+        </div>
+        <div>
+          <p>Abbreviate Threshold:</p>
+          <UInput v-model="values.abbreviateThreshold" type="number" />
+        </div>
+        <div>
+          <p>Subscript Threshold:</p>
+          <UInput v-model="values.subscriptThresholdDecimals" type="number" />
+        </div>
+        <div>
+          <p>Subscript Decimals:</p>
+          <UInput v-model="values.subscriptDecimals" type="number" />
+        </div>
+      </UCard>
+
+      <UCard>
+        <div class="grid grid-cols-2 lg:grid-cols-4 gap-5">
+          <UButton
+            variant="outline"
+            v-for="testNumber in testNumbers"
+            :key="testNumber"
+            @click="values.amount = testNumber"
+          >
+            <p>{{ testNumber }}</p>
+          </UButton>
+        </div>
+      </UCard>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-5 mt-5">
+      <template
+        v-for="useAbbreviation in [false, true]"
+        :key="useAbbreviation.toString()"
+      >
+        <template
+          v-for="noTrailingZeros in [false, true]"
+          :key="noTrailingZeros.toString()"
+        >
+          <template
+            v-for="useSubscript in [false, true]"
+            :key="useSubscript.toString()"
+          >
+            <UCard>
+              <div class="text-xs">
+                <p>
+                  Should Abbreviate:
+                  <span
+                    class="font-bold"
+                    :class="[
+                      useAbbreviation ? 'text-green-500' : 'text-red-500',
+                    ]"
+                    >{{ useAbbreviation }}</span
+                  >
+                </p>
+                <p>
+                  No Trailing Zeros:
+                  <span
+                    class="font-bold"
+                    :class="[
+                      noTrailingZeros ? 'text-green-500' : 'text-red-500',
+                    ]"
+                    >{{ noTrailingZeros }}</span
+                  >
+                </p>
+                <p>
+                  Use Subscript:
+                  <span
+                    class="font-bold"
+                    :class="[useSubscript ? 'text-green-500' : 'text-red-500']"
+                    >{{ useSubscript }}</span
+                  >
+                </p>
+
+                <p class="text-right border-t pt-2 mt-2">
+                  <SharedAmountDisplay
+                    class="text-2xl"
+                    v-bind="{
+                      amount: values.amount,
+                      abbreviationThreshold: Number(values.abbreviateThreshold),
+                      decimals: Number(values.decimals),
+                      subscriptDecimals: Number(values.subscriptDecimals),
+                      subscriptThresholdDecimals: Number(
+                        values.subscriptThresholdDecimals,
+                      ),
+                      useAbbreviation,
+                      noTrailingZeros,
+                      useSubscript,
+                    }"
+                  />
+                </p>
+              </div>
+            </UCard>
+          </template>
+        </template>
+      </template>
+    </div>
+  </div>
+</template>

--- a/layer/pages/playground.vue
+++ b/layer/pages/playground.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const values = reactive({
   amount: "1",
-  decimals: 6,
+  decimals: 8,
   abbreviateThreshold: 1000000,
   subscriptThresholdDecimals: 4,
   subscriptDecimals: 4,
@@ -10,12 +10,13 @@ const values = reactive({
 const testNumbers = [
   "0.0000001",
   "0.01",
+  "0.0110000",
   "1.1",
   "1000",
   "1000000",
   "1000000000.123",
   "1000.000000000123",
-  "1000.123",
+  "1000.1234567891",
   "1580000.123",
   "1230000000.123",
 
@@ -93,68 +94,50 @@ const testNumbers = [
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-5 mt-5">
       <template
-        v-for="useAbbreviation in [false, true]"
-        :key="useAbbreviation.toString()"
+        v-for="noTrailingZeros in [false, true]"
+        :key="noTrailingZeros.toString()"
       >
         <template
-          v-for="noTrailingZeros in [false, true]"
-          :key="noTrailingZeros.toString()"
+          v-for="useSubscript in [false, true]"
+          :key="useSubscript.toString()"
         >
-          <template
-            v-for="useSubscript in [false, true]"
-            :key="useSubscript.toString()"
-          >
-            <UCard>
-              <div class="text-xs">
-                <p>
-                  Should Abbreviate:
-                  <span
-                    class="font-bold"
-                    :class="[
-                      useAbbreviation ? 'text-green-500' : 'text-red-500',
-                    ]"
-                    >{{ useAbbreviation }}</span
-                  >
-                </p>
-                <p>
-                  No Trailing Zeros:
-                  <span
-                    class="font-bold"
-                    :class="[
-                      noTrailingZeros ? 'text-green-500' : 'text-red-500',
-                    ]"
-                    >{{ noTrailingZeros }}</span
-                  >
-                </p>
-                <p>
-                  Use Subscript:
-                  <span
-                    class="font-bold"
-                    :class="[useSubscript ? 'text-green-500' : 'text-red-500']"
-                    >{{ useSubscript }}</span
-                  >
-                </p>
+          <UCard>
+            <div class="text-xs">
+              <p>
+                No Trailing Zeros:
+                <span
+                  class="font-bold"
+                  :class="[noTrailingZeros ? 'text-green-500' : 'text-red-500']"
+                  >{{ noTrailingZeros }}</span
+                >
+              </p>
+              <p>
+                Use Subscript:
+                <span
+                  class="font-bold"
+                  :class="[useSubscript ? 'text-green-500' : 'text-red-500']"
+                  >{{ useSubscript }}</span
+                >
+              </p>
 
-                <p class="text-right border-t pt-2 mt-2">
-                  <SharedAmountDisplay
-                    class="text-2xl"
-                    v-bind="{
-                      amount: values.amount,
-                      abbreviationThreshold: Number(values.abbreviateThreshold),
-                      decimals: Number(values.decimals),
-                      subscriptDecimals: Number(values.subscriptDecimals),
-                      subscriptThresholdDecimals: Number(
-                        values.subscriptThresholdDecimals,
-                      ),
-                      useAbbreviation,
-                      noTrailingZeros,
-                      useSubscript,
-                    }"
-                  />
-                </p>
-              </div>
-            </UCard>
-          </template>
+              <p class="text-right border-t pt-2 mt-2">
+                <SharedAmountDisplay
+                  class="text-2xl"
+                  v-bind="{
+                    useSubscript,
+                    noTrailingZeros,
+                    amount: values.amount,
+                    decimals: Number(values.decimals),
+                    subscriptDecimals: Number(values.subscriptDecimals),
+                    abbreviationThreshold: Number(values.abbreviateThreshold),
+                    subscriptThresholdDecimals: Number(
+                      values.subscriptThresholdDecimals,
+                    ),
+                  }"
+                />
+              </p>
+            </div>
+          </UCard>
         </template>
       </template>
     </div>

--- a/layer/utils/constant/index.ts
+++ b/layer/utils/constant/index.ts
@@ -1,46 +1,48 @@
 import {
   BigNumber,
   BigNumberInWei,
-  BigNumberInBase
-} from '@injectivelabs/utils'
+  BigNumberInBase,
+} from "@injectivelabs/utils";
 
-export * from './setup'
+export * from "./setup";
 
 export const INJ_LOGO_URL =
-  'https://imagedelivery.net/lPzngbR8EltRfBOi_WYaXw/efaa2c96-5463-4707-0d2b-19e5b63df000/public'
+  "https://imagedelivery.net/lPzngbR8EltRfBOi_WYaXw/efaa2c96-5463-4707-0d2b-19e5b63df000/public";
 export const INJ_LOGO_DARK_URL =
-  'https://imagedelivery.net/lPzngbR8EltRfBOi_WYaXw/60aee853-77a2-40b1-04bd-b4aba9312000/public'
+  "https://imagedelivery.net/lPzngbR8EltRfBOi_WYaXw/60aee853-77a2-40b1-04bd-b4aba9312000/public";
 export const USDT_LOGO_URL =
-  'https://imagedelivery.net/lPzngbR8EltRfBOi_WYaXw/a0bd252b-1005-47ef-d209-7c1c4a3cbf00/public'
+  "https://imagedelivery.net/lPzngbR8EltRfBOi_WYaXw/a0bd252b-1005-47ef-d209-7c1c4a3cbf00/public";
 export const AUSD_LOGO_URL =
-  'https://imagedelivery.net/lPzngbR8EltRfBOi_WYaXw/4b446611-8af6-424f-abc6-e41defe1d800/public'
+  "https://imagedelivery.net/lPzngbR8EltRfBOi_WYaXw/4b446611-8af6-424f-abc6-e41defe1d800/public";
 export const UNKNOWN_LOGO_URL =
-  'https://imagedelivery.net/lPzngbR8EltRfBOi_WYaXw/6f015260-c589-499f-b692-a57964af9900/public'
+  "https://imagedelivery.net/lPzngbR8EltRfBOi_WYaXw/6f015260-c589-499f-b692-a57964af9900/public";
 
-export const INJ_DENOM = 'inj'
-export const ETH_DENOM = 'peggy0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-export const USDT_DENOM = 'peggy0xdAC17F958D2ee523a2206206994597C13D831ec7'
+export const INJ_DENOM = "inj";
+export const ETH_DENOM = "peggy0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+export const USDT_DENOM = "peggy0xdAC17F958D2ee523a2206206994597C13D831ec7";
 export const BINANCE_DEPOSIT_ADDRESS =
-  'inj1u2rajhqtptzvu23leheta9yg99k3hazf4waf43'
+  "inj1u2rajhqtptzvu23leheta9yg99k3hazf4waf43";
 
-export const ZERO_IN_WEI: BigNumberInWei = new BigNumberInWei(0)
-export const ZERO_IN_BASE: BigNumberInBase = new BigNumberInBase(0)
+export const ZERO_IN_WEI: BigNumberInWei = new BigNumberInWei(0);
+export const ZERO_IN_BASE: BigNumberInBase = new BigNumberInBase(0);
 // eslint-disable-next-line  prefer-regex-literals
-export const NUMBER_REGEX = new RegExp(/^-?(0|[1-9]\d*)?(\.\d+)?$/)
+export const NUMBER_REGEX = new RegExp(/^-?(0|[1-9]\d*)?(\.\d+)?$/);
 
-export const GWEI_IN_WEI: BigNumber = new BigNumber(1000000000)
-export const DEFAULT_GAS_PRICE = new BigNumber(120).times(GWEI_IN_WEI)
-export const DEFAULT_MAINNET_GAS_PRICE = new BigNumber(30).times(GWEI_IN_WEI)
-export const INJ_REQUIRED_FOR_GAS = 0.005
+export const GWEI_IN_WEI: BigNumber = new BigNumber(1000000000);
+export const DEFAULT_GAS_PRICE = new BigNumber(120).times(GWEI_IN_WEI);
+export const DEFAULT_MAINNET_GAS_PRICE = new BigNumber(30).times(GWEI_IN_WEI);
+export const INJ_REQUIRED_FOR_GAS = 0.005;
 
-export const UTC_TIMEZONE = 'Etc/Greenwich'
+export const UTC_TIMEZONE = "Etc/Greenwich";
 
 export const MSG_TYPE_URL_MSG_EXECUTE_CONTRACT =
-  '/injective.wasmx.v1.MsgExecuteContractCompat'
+  "/injective.wasmx.v1.MsgExecuteContractCompat";
 
-export const JSON_POLL_INTERVAL = 1000 * 60 * 10 // 10 minutes
+export const JSON_POLL_INTERVAL = 1000 * 60 * 10; // 10 minutes
 
-export const DEFAULT_NOTIFICATION_TIMEOUT = 6 * 1000
+export const DEFAULT_NOTIFICATION_TIMEOUT = 6 * 1000;
 
-export const NOTIFI_LINK = 'https://injective.notifi.network'
-export const TURNKEY_CONTAINER_ID = 'turnkey-auth-iframe-container-id'
+export const NOTIFI_LINK = "https://injective.notifi.network";
+export const TURNKEY_CONTAINER_ID = "turnkey-auth-iframe-container-id";
+
+export const DEFAULT_ABBREVIATION_THRESHOLD = 1_000_000;

--- a/layer/utils/helper.ts
+++ b/layer/utils/helper.ts
@@ -1,10 +1,11 @@
-import { sharedTokenClient, tokenStaticFactory } from '../Service'
-import type { TokenStatic } from '@injectivelabs/sdk-ts'
+import { BigNumberInBase } from "@injectivelabs/utils";
+import type { TokenStatic } from "@injectivelabs/sdk-ts";
+import { sharedTokenClient, tokenStaticFactory } from "../Service";
 
 export const sharedGetToken = async (
   denomOrSymbol: string
 ): Promise<undefined | TokenStatic> => {
-  const token = tokenStaticFactory.toToken(denomOrSymbol)
+  const token = tokenStaticFactory.toToken(denomOrSymbol);
 
   if (token) {
     return token
@@ -13,4 +14,40 @@ export const sharedGetToken = async (
   const asyncToken = await sharedTokenClient.queryToken(denomOrSymbol)
 
   return asyncToken
-}
+};
+
+export const unAbbreviateNumber = (
+  value: string,
+): BigNumberInBase | undefined => {
+  const units = {
+    K: Number(`1${"0".repeat(3)}`),
+    M: Number(`1${"0".repeat(6)}`),
+    B: Number(`1${"0".repeat(9)}`),
+    T: Number(`1${"0".repeat(12)}`),
+  } as Record<string, number>;
+
+  const unit = value.at(-1);
+
+  if (!unit || !units[unit]) {
+    return;
+  }
+
+  const formattedValue = value.replaceAll(",", "").slice(0, -1);
+
+  return new BigNumberInBase(formattedValue).multipliedBy(units[unit]);
+};
+
+export const abbreviateNumber = (number: number) => {
+  const abbreviatedValue = new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    compactDisplay: "short",
+  }).format(number);
+
+  const abbreviatedValueMatchesInput = new BigNumberInBase(number).eq(
+    unAbbreviateNumber(abbreviatedValue) || "0",
+  );
+
+  return abbreviatedValueMatchesInput
+    ? abbreviatedValue
+    : `≈${abbreviatedValue}`;
+};


### PR DESCRIPTION
## Amount Formatter

- Main Component: `AmountDisplay`

- UsdAmount component: `SharedAmountUsdDisplay`
- Amount Component: `SharedAmountFormatted`

Usage examples in the `/playground` page.
to access it open up helix with `yarn dev:local` and navigate to '/playground'

<img width="1785" alt="image" src="https://github.com/user-attachments/assets/283382f9-1708-4365-863a-c35b13c49d49" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new components for displaying and formatting numeric amounts with customizable options, including abbreviation, subscript formatting, and trailing zero removal.
  - Added a USD display component for amounts with optional dollar sign and abbreviation formatting.
  - Provided a playground page for interactively testing and visualizing different numeric formatting combinations.
  - Added utility functions for number abbreviation and expansion, and a default abbreviation threshold constant.

- **Style**
  - Updated configuration and code formatting for consistent style, including quote usage and trailing commas.

- **Chores**
  - Removed Prettier configuration files to streamline project formatting settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->