### PR TITLE
feat/amount-formatter-refinements

### DIFF
--- a/layer/components/Amount/Formatted.vue
+++ b/layer/components/Amount/Formatted.vue
@@ -1,20 +1,27 @@
 <script setup lang="ts">
 import { BigNumberInBase } from "@injectivelabs/utils";
+import { DEFAULT_ABBREVIATION_THRESHOLD } from "../../utils/constant";
 
 const props = withDefaults(
   defineProps<{
-    amount: string | number | BigNumberInBase;
     decimals?: number;
+    useSubscript?: boolean;
     noTrailingZeros?: boolean;
+    abbreviationThreshold?: number;
+    amount: string | number | BigNumberInBase;
   }>(),
   {
-    decimals: 6,
+    decimals: 8,
     noTrailingZeros: true,
+    abbreviationThreshold: DEFAULT_ABBREVIATION_THRESHOLD,
   },
 );
 
 const decimals = computed(() => {
-  if (new BigNumberInBase(props.amount || 0).gt(1_000_000)) {
+  if (
+    !!props.abbreviationThreshold &&
+    new BigNumberInBase(props.amount || 0).gt(props.abbreviationThreshold)
+  ) {
     return 2;
   }
 
@@ -27,8 +34,9 @@ const decimals = computed(() => {
     v-bind="{
       amount,
       decimals,
-      useSubscript: true,
+      useSubscript,
       noTrailingZeros,
+      abbreviationThreshold,
     }"
   />
 </template>

--- a/layer/components/Amount/UsdDisplay.vue
+++ b/layer/components/Amount/UsdDisplay.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import type { BigNumberInBase } from "@injectivelabs/utils";
+import { DEFAULT_ABBREVIATION_THRESHOLD } from "../../utils/constant";
 
 withDefaults(
   defineProps<{
-    amount: string | number | BigNumberInBase;
     showSign?: boolean;
+    abbreviationThreshold?: number;
+    amount: string | number | BigNumberInBase;
   }>(),
   {
     showSign: true,
+    abbreviationThreshold: DEFAULT_ABBREVIATION_THRESHOLD,
   },
 );
 </script>
@@ -15,6 +18,12 @@ withDefaults(
 <template>
   <span>
     <span v-if="showSign">$ </span>
-    <SharedAmountDisplay :amount="amount" :decimals="2" use-abbreviation />
+    <SharedAmountDisplay
+      v-bind="{
+        amount,
+        decimals: 2,
+        abbreviationThreshold,
+      }"
+    />
   </span>
 </template>

--- a/layer/composables/useSharedBigNumberFormatted.ts
+++ b/layer/composables/useSharedBigNumberFormatted.ts
@@ -3,6 +3,7 @@ import {
   BigNumberInBase,
   getExactDecimalsFromNumber
 } from '@injectivelabs/utils'
+import { abbreviateNumber } from '../utils/helper'
 
 const ZERO_IN_BASE = new BigNumberInBase(0)
 const DEFAULT_DECIMAL_PLACES = 2
@@ -17,40 +18,6 @@ const getFormattedZeroValue = (decimalPlaces: number) => {
   }
 
   return '0.0'
-}
-
-const unAbbreviateNumber = (value: string): BigNumberInBase | undefined => {
-  const units = {
-    K: Number(`1${'0'.repeat(3)}`),
-    M: Number(`1${'0'.repeat(6)}`),
-    B: Number(`1${'0'.repeat(9)}`),
-    T: Number(`1${'0'.repeat(12)}`)
-  } as Record<string, number>
-
-  const unit = value.at(-1)
-
-  if (!unit || !units[unit]) {
-    return
-  }
-
-  const formattedValue = value.replaceAll(',', '').slice(0, -1)
-
-  return new BigNumberInBase(formattedValue).multipliedBy(units[unit])
-}
-
-const abbreviateNumber = (number: number) => {
-  const abbreviatedValue = new Intl.NumberFormat('en-US', {
-    notation: 'compact',
-    compactDisplay: 'short'
-  }).format(number)
-
-  const abbreviatedValueMatchesInput = new BigNumberInBase(number).eq(
-    unAbbreviateNumber(abbreviatedValue) || '0'
-  )
-
-  return abbreviatedValueMatchesInput
-    ? abbreviatedValue
-    : `≈${abbreviatedValue}`
 }
 
 const getNumberMinimalDecimals = (

--- a/layer/pages/playground.vue
+++ b/layer/pages/playground.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const values = reactive({
   amount: "1",
-  decimals: 6,
+  decimals: 8,
   abbreviateThreshold: 1000000,
   subscriptThresholdDecimals: 4,
   subscriptDecimals: 4,
@@ -10,12 +10,13 @@ const values = reactive({
 const testNumbers = [
   "0.0000001",
   "0.01",
+  "0.0110000",
   "1.1",
   "1000",
   "1000000",
   "1000000000.123",
   "1000.000000000123",
-  "1000.123",
+  "1000.1234567891",
   "1580000.123",
   "1230000000.123",
 
@@ -93,68 +94,50 @@ const testNumbers = [
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-5 mt-5">
       <template
-        v-for="useAbbreviation in [false, true]"
-        :key="useAbbreviation.toString()"
+        v-for="noTrailingZeros in [false, true]"
+        :key="noTrailingZeros.toString()"
       >
         <template
-          v-for="noTrailingZeros in [false, true]"
-          :key="noTrailingZeros.toString()"
+          v-for="useSubscript in [false, true]"
+          :key="useSubscript.toString()"
         >
-          <template
-            v-for="useSubscript in [false, true]"
-            :key="useSubscript.toString()"
-          >
-            <UCard>
-              <div class="text-xs">
-                <p>
-                  Should Abbreviate:
-                  <span
-                    class="font-bold"
-                    :class="[
-                      useAbbreviation ? 'text-green-500' : 'text-red-500',
-                    ]"
-                    >{{ useAbbreviation }}</span
-                  >
-                </p>
-                <p>
-                  No Trailing Zeros:
-                  <span
-                    class="font-bold"
-                    :class="[
-                      noTrailingZeros ? 'text-green-500' : 'text-red-500',
-                    ]"
-                    >{{ noTrailingZeros }}</span
-                  >
-                </p>
-                <p>
-                  Use Subscript:
-                  <span
-                    class="font-bold"
-                    :class="[useSubscript ? 'text-green-500' : 'text-red-500']"
-                    >{{ useSubscript }}</span
-                  >
-                </p>
+          <UCard>
+            <div class="text-xs">
+              <p>
+                No Trailing Zeros:
+                <span
+                  class="font-bold"
+                  :class="[noTrailingZeros ? 'text-green-500' : 'text-red-500']"
+                  >{{ noTrailingZeros }}</span
+                >
+              </p>
+              <p>
+                Use Subscript:
+                <span
+                  class="font-bold"
+                  :class="[useSubscript ? 'text-green-500' : 'text-red-500']"
+                  >{{ useSubscript }}</span
+                >
+              </p>
 
-                <p class="text-right border-t pt-2 mt-2">
-                  <SharedAmountDisplay
-                    class="text-2xl"
-                    v-bind="{
-                      amount: values.amount,
-                      abbreviationThreshold: Number(values.abbreviateThreshold),
-                      decimals: Number(values.decimals),
-                      subscriptDecimals: Number(values.subscriptDecimals),
-                      subscriptThresholdDecimals: Number(
-                        values.subscriptThresholdDecimals,
-                      ),
-                      useAbbreviation,
-                      noTrailingZeros,
-                      useSubscript,
-                    }"
-                  />
-                </p>
-              </div>
-            </UCard>
-          </template>
+              <p class="text-right border-t pt-2 mt-2">
+                <SharedAmountDisplay
+                  class="text-2xl"
+                  v-bind="{
+                    useSubscript,
+                    noTrailingZeros,
+                    amount: values.amount,
+                    decimals: Number(values.decimals),
+                    subscriptDecimals: Number(values.subscriptDecimals),
+                    abbreviationThreshold: Number(values.abbreviateThreshold),
+                    subscriptThresholdDecimals: Number(
+                      values.subscriptThresholdDecimals,
+                    ),
+                  }"
+                />
+              </p>
+            </div>
+          </UCard>
         </template>
       </template>
     </div>

--- a/layer/utils/constant/index.ts
+++ b/layer/utils/constant/index.ts
@@ -43,3 +43,5 @@ export const JSON_POLL_INTERVAL = 1000 * 60 * 10 // 10 minutes
 export const DEFAULT_NOTIFICATION_TIMEOUT = 6 * 1000
 
 export const NOTIFI_LINK = 'https://injective.notifi.network'
+
+export const DEFAULT_ABBREVIATION_THRESHOLD = 1_000_000

--- a/layer/utils/helper.ts
+++ b/layer/utils/helper.ts
@@ -1,10 +1,11 @@
-import { sharedTokenClient, tokenStaticFactory } from '../Service'
-import type { TokenStatic } from '@injectivelabs/sdk-ts'
+import { BigNumberInBase } from "@injectivelabs/utils";
+import type { TokenStatic } from "@injectivelabs/sdk-ts";
+import { sharedTokenClient, tokenStaticFactory } from "../Service";
 
 export const sharedGetToken = async (
   denomOrSymbol: string
 ): Promise<undefined | TokenStatic> => {
-  const token = tokenStaticFactory.toToken(denomOrSymbol)
+  const token = tokenStaticFactory.toToken(denomOrSymbol);
 
   if (token) {
     return token
@@ -13,4 +14,40 @@ export const sharedGetToken = async (
   const asyncToken = await sharedTokenClient.queryToken(denomOrSymbol)
 
   return asyncToken
-}
+};
+
+export const unAbbreviateNumber = (
+  value: string,
+): BigNumberInBase | undefined => {
+  const units = {
+    K: Number(`1${"0".repeat(3)}`),
+    M: Number(`1${"0".repeat(6)}`),
+    B: Number(`1${"0".repeat(9)}`),
+    T: Number(`1${"0".repeat(12)}`),
+  } as Record<string, number>;
+
+  const unit = value.at(-1);
+
+  if (!unit || !units[unit]) {
+    return;
+  }
+
+  const formattedValue = value.replaceAll(",", "").slice(0, -1);
+
+  return new BigNumberInBase(formattedValue).multipliedBy(units[unit]);
+};
+
+export const abbreviateNumber = (number: number) => {
+  const abbreviatedValue = new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    compactDisplay: "short",
+  }).format(number);
+
+  const abbreviatedValueMatchesInput = new BigNumberInBase(number).eq(
+    unAbbreviateNumber(abbreviatedValue) || "0",
+  );
+
+  return abbreviatedValueMatchesInput
+    ? abbreviatedValue
+    : `≈${abbreviatedValue}`;
+};


### PR DESCRIPTION
*Changes : 
1. `general - abbreviation`
a. unite with abbreviation system that we had or used for hub/explorer + useSharedBigNumberFormatter
b. refinements from previous abbreviation = removed non significant zero + conditionally add `≈` for numbers that need further clarity
c. abbreviate enabled by default, starting from 1M

2. `AmountFormatted`
a. by default = subscript disabled
b. by default = always 8 decimals + noTrailingZeroes
c. fixed round up issue when last time we saw `0.12345679` (which supposely `0.12345678`)

---
*Note:
1. we have flexibility to modify props if needed on some section (e.g if don't want abbreviation, can just set `abbreviationThreshold` to `0`)

2. for abbreviation tooltip, each product will have like `AppAmount` & `AppUsdAmount` with content similar to snapshots, to have `nuxt-ui` tooltip that will show the full number (surely can use `layer's` constant variables to unite)

![image](https://github.com/user-attachments/assets/446cd6e2-df12-4e91-b0c9-46c388f0c396)
![image](https://github.com/user-attachments/assets/abc6ebca-8505-4356-8e86-87e6ea2014ac)

---
*Usecases 1 min Recording: [loom link](https://www.loom.com/share/7072e6892cdf4f10875feab749e18456?sid=0dc7199f-d309-4ea2-b036-910f08df5831)

