### PR TITLE
fix/trailing-zeros-for-subscript

### DIFF
--- a/layer/components/Amount/Base.vue
+++ b/layer/components/Amount/Base.vue
@@ -82,9 +82,13 @@ const subscriptedAmount = computed(() => {
     nOfZeros > props.decimals ||
     nOfZeros > props.subscriptThresholdDecimals
   ) {
-    const subscriptAmount = new BigNumberInBase(decimalPart.replace(/^0+/, ''))
+    let subscriptAmount = new BigNumberInBase(decimalPart.replace(/^0+/, ''))
       .toFixed(0)
       .slice(0, props.subscriptDecimals)
+
+    if (!props.noTrailingZeros) {
+      subscriptAmount = subscriptAmount.padEnd(props.subscriptDecimals, '0')
+    }
 
     const integerAmount = new BigNumberInBase(integerPart).toFormat(0)
 

--- a/layer/components/Amount/Index.spec.ts
+++ b/layer/components/Amount/Index.spec.ts
@@ -247,5 +247,19 @@ describe('Amount/Index.vue', () => {
 
       expect(component.text()).toBe('1.5')
     })
+
+    it('trailing zeros with subscripts', async () => {
+      const component = await mountSuspended(Index, {
+        props: {
+          amount: '0.00001',
+          useSubscript: true,
+          noTrailingZeros: false
+        }
+      })
+
+      expect(component.html()).toMatchInlineSnapshot(
+        `"<span><!--v-if--><span>0.0<sub>4</sub>1000</span></span>"`
+      )
+    })
   })
 })


### PR DESCRIPTION
This PR fixes the subscripted amount computation to support trailing zeros.  
Preview in Helix OB :
<img width="301" height="137" alt="Capture d’écran 2025-07-24 à 18 02 55" src="https://github.com/user-attachments/assets/385590cf-ddae-41da-8507-3beab0adc280" />
