### PR TITLE
fix/amount-subscript-decimals

### DIFF
--- a/components/Amount/Base.vue
+++ b/components/Amount/Base.vue
@@ -81,7 +81,7 @@ const subscriptedAmount = computed(() => {
   }
 
   if (
-    nOfZeros > props.decimals ||
+    nOfZeros >= props.decimals ||
     nOfZeros > props.subscriptThresholdDecimals
   ) {
     let subscriptAmount = new BigNumberInBase(decimalPart.replace(/^0+/, ''))

--- a/components/Amount/Index.spec.ts
+++ b/components/Amount/Index.spec.ts
@@ -96,7 +96,7 @@ describe('Amount/Index.vue', () => {
       })
 
       expect(component.html()).toMatchInlineSnapshot(
-        `"<span><!--v-if--><span>0</span></span>"`
+        `"<span><!--v-if--><span>0.0<sub>2</sub>1234</span></span>"`
       )
     })
 
@@ -112,6 +112,18 @@ describe('Amount/Index.vue', () => {
       expect(component.html()).toMatchInlineSnapshot(
         `"<span><!--v-if--><span>0.0<sub>3</sub>1234</span></span>"`
       )
+    })
+
+    it('uses a subscript for small numbers when useSubscript is true and decimals is smaller than subscriptThresholdDecimals', async () => {
+      const component = await mountSuspended(Index, {
+        props: {
+          decimals: 2,
+          useSubscript: true,
+          amount: '0.001234'
+        }
+      })
+
+      expect(component.html()).toMatchInlineSnapshot(`"<span><!--v-if--><span>0.0<sub>2</sub>1234</span></span>"`)
     })
   })
 

--- a/components/Amount/Usd.spec.ts
+++ b/components/Amount/Usd.spec.ts
@@ -326,6 +326,50 @@ describe('Amount/Usd.vue', () => {
     })
   })
 
+  describe('subscript behavior', () => {
+    it('uses subscript for very small numbers when useSubscript is true', async () => {
+      const component = await mountSuspended(Usd, {
+        props: {
+          amount: '0.001234',
+          useSubscript: true
+        },
+        slots: {
+          prefix: () => '$'
+        }
+      })
+
+      expect(component.html()).toMatchInlineSnapshot(`"<span><!--v-if-->$<span>0.0<sub>2</sub>1234</span></span>"`)
+    })
+
+    it('does not use subscript when useSubscript is false', async () => {
+      const component = await mountSuspended(Usd, {
+        props: {
+          amount: '0.001234',
+          useSubscript: false
+        },
+        slots: {
+          prefix: () => '$'
+        }
+      })
+
+      expect(component.html()).toMatchInlineSnapshot(`"<span><!--v-if-->$<span>&lt;0.01</span></span>"`)
+    })
+
+    it('works with negative numbers and subscript', async () => {
+      const component = await mountSuspended(Usd, {
+        props: {
+          amount: '-0.001234',
+          useSubscript: true
+        },
+        slots: {
+          prefix: () => '$'
+        }
+      })
+
+      expect(component.html()).toMatchInlineSnapshot(`"<span><span>-</span>$<span>0.0<sub>2</sub>1234</span></span>"`)
+    })
+  })
+
   describe('slot behavior', () => {
     it('works without prefix slot', async () => {
       const component = await mountSuspended(Usd, {

--- a/components/Amount/Usd.vue
+++ b/components/Amount/Usd.vue
@@ -7,6 +7,7 @@ withDefaults(
     dataCy?: string
     cyValue?: string
     hideDecimals?: boolean
+    useSubscript?: boolean
     shouldAbbreviate?: boolean
     roundingMode?: BigNumber.RoundingMode
     amount: string | number | BigNumberInBase
@@ -24,6 +25,7 @@ withDefaults(
       amount,
       dataCy,
       cyValue,
+      useSubscript,
       roundingMode,
       shouldAbbreviate,
       decimals: hideDecimals ? 0 : DEFAULT_USD_DECIMALS


### PR DESCRIPTION
Fixes : 
- Bug where subscript wouldn't trigger for values with a specific number of zeros
  - ex: 0.002 shown with 2 decimals AND subscript enabled would display as 0.00 instead of 0.0_{2}2

Adds : 
- **useSubscript** prop to AmountUsd component, allowing to show full USD price values without having ">"
  - ex: $0.0000002 was shown as >$0.01, now can be $0.0_{6}2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added optional useSubscript prop to USD amount display, enabling subscript formatting for very small values.
- Bug Fixes
  - Refined threshold so subscript formatting appears in boundary cases where fractional leading zeros match the configured decimals.
- Tests
  - Expanded test coverage for subscript formatting, including cases with small positive and negative amounts and toggling useSubscript on/off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->