### PR TITLE
fix: rounded value not used with less than

### DIFF
--- a/app/components/Amount/Base.vue
+++ b/app/components/Amount/Base.vue
@@ -46,7 +46,13 @@ const shouldHaveSmallerThan = computed(() => {
   const amount = absoluteAmount.value
   const nIsLowerThanDecimalThreshold = amount.lt(minDecimalThreshold.value)
 
-  return nIsLowerThanDecimalThreshold && amount.gt(0) && !props.useSubscript
+  if (!nIsLowerThanDecimalThreshold || amount.lte(0) || props.useSubscript) {
+    return false
+  }
+
+  const roundedAmount = amount.dp(props.decimals, props.roundingMode)
+
+  return roundedAmount.lte(0)
 })
 
 const abbreviatedAmount = computed(() => {

--- a/app/components/Amount/Index.spec.ts
+++ b/app/components/Amount/Index.spec.ts
@@ -283,6 +283,46 @@ describe('Amount/Index.vue', () => {
 
       expect(component.text()).toBe('2.00')
     })
+
+    it('shows rounded value instead of "<" when rounding crosses the threshold', async () => {
+      const component = await mountSuspended(Index, {
+        props: {
+          amount: '0.99',
+          decimals: 0,
+          shouldAbbreviate: false,
+          roundingMode: BigNumber.ROUND_HALF_UP
+        }
+      })
+
+      expect(component.text()).toBe('1')
+    })
+
+    it('shows "<" when rounding does not cross the threshold', async () => {
+      const component = await mountSuspended(Index, {
+        props: {
+          amount: '0.49',
+          decimals: 0,
+          shouldAbbreviate: false,
+          roundingMode: BigNumber.ROUND_HALF_UP
+        }
+      })
+
+      expect(component.html()).toMatchInlineSnapshot(
+        `"<span><!--v-if--><span>&lt;1</span></span>"`
+      )
+    })
+
+    it('shows rounded value when ROUND_UP crosses decimal threshold', async () => {
+      const component = await mountSuspended(Index, {
+        props: {
+          amount: '0.001',
+          decimals: 2,
+          roundingMode: BigNumber.ROUND_UP
+        }
+      })
+
+      expect(component.text()).toBe('0.01')
+    })
   })
 
   describe('prop combinations', () => {

--- a/app/components/Amount/Index.spec.ts
+++ b/app/components/Amount/Index.spec.ts
@@ -323,6 +323,44 @@ describe('Amount/Index.vue', () => {
 
       expect(component.text()).toBe('0.01')
     })
+
+    it('ROUND_CEIL on negative amount rounds consistently with sign/magnitude split', async () => {
+      const component = await mountSuspended(Index, {
+        props: {
+          decimals: 2,
+          amount: '-1.999',
+          noTrailingZeros: false,
+          roundingMode: BigNumber.ROUND_CEIL
+        }
+      })
+
+      expect(component.text()).toBe('-2.00')
+    })
+
+    it('ROUND_FLOOR on negative amount rounds consistently with sign/magnitude split', async () => {
+      const component = await mountSuspended(Index, {
+        props: {
+          decimals: 2,
+          amount: '-1.111',
+          noTrailingZeros: false,
+          roundingMode: BigNumber.ROUND_FLOOR
+        }
+      })
+
+      expect(component.text()).toBe('-1.11')
+    })
+
+    it('ROUND_CEIL on small negative amount shows "<" consistently', async () => {
+      const component = await mountSuspended(Index, {
+        props: {
+          decimals: 2,
+          amount: '-0.001',
+          roundingMode: BigNumber.ROUND_CEIL
+        }
+      })
+
+      expect(component.text()).toBe('-0.01')
+    })
   })
 
   describe('prop combinations', () => {

--- a/app/components/Amount/Index.spec.ts
+++ b/app/components/Amount/Index.spec.ts
@@ -79,8 +79,8 @@ describe('Amount/Index.vue', () => {
     it(`when shouldAbbreviate is false, there is no decimals when above ${DEFAULT_ABBREVIATION_THRESHOLD}`, async () => {
       const component = await mountSuspended(Index, {
         props: {
-          amount: `${DEFAULT_ABBREVIATION_THRESHOLD}.12345678`,
-          shouldAbbreviate: false
+          shouldAbbreviate: false,
+          amount: `${DEFAULT_ABBREVIATION_THRESHOLD}.12345678`
         }
       })
 
@@ -90,8 +90,8 @@ describe('Amount/Index.vue', () => {
     it(`when shouldAbbreviate is false, there is no decimals when below ${DEFAULT_ABBREVIATION_THRESHOLD}`, async () => {
       const component = await mountSuspended(Index, {
         props: {
-          amount: `100000.12345678`,
-          shouldAbbreviate: false
+          shouldAbbreviate: false,
+          amount: `100000.12345678`
         }
       })
 
@@ -141,8 +141,8 @@ describe('Amount/Index.vue', () => {
       const component = await mountSuspended(Index, {
         props: {
           decimals: 0,
-          useSubscript: true,
-          amount: '0.5'
+          amount: '0.5',
+          useSubscript: true
         }
       })
 
@@ -154,8 +154,8 @@ describe('Amount/Index.vue', () => {
       const component = await mountSuspended(Index, {
         props: {
           decimals: 2,
-          useSubscript: true,
-          amount: '0.001234'
+          amount: '0.001234',
+          useSubscript: true
         }
       })
 
@@ -169,8 +169,8 @@ describe('Amount/Index.vue', () => {
     it('respects custom decimals', async () => {
       const component = await mountSuspended(Index, {
         props: {
-          amount: '1.123456789',
-          decimals: 2
+          decimals: 2,
+          amount: '1.123456789'
         }
       })
 
@@ -263,8 +263,8 @@ describe('Amount/Index.vue', () => {
     it('uses ROUND_DOWN by default', async () => {
       const component = await mountSuspended(Index, {
         props: {
-          amount: '1.999999',
-          decimals: 2
+          decimals: 2,
+          amount: '1.999999'
         }
       })
 
@@ -274,10 +274,10 @@ describe('Amount/Index.vue', () => {
     it('respects custom rounding mode', async () => {
       const component = await mountSuspended(Index, {
         props: {
-          amount: '1.999999',
           decimals: 2,
-          roundingMode: BigNumber.ROUND_UP,
-          noTrailingZeros: false
+          amount: '1.999999',
+          noTrailingZeros: false,
+          roundingMode: BigNumber.ROUND_UP
         }
       })
 
@@ -287,8 +287,8 @@ describe('Amount/Index.vue', () => {
     it('shows rounded value instead of "<" when rounding crosses the threshold', async () => {
       const component = await mountSuspended(Index, {
         props: {
-          amount: '0.99',
           decimals: 0,
+          amount: '0.99',
           shouldAbbreviate: false,
           roundingMode: BigNumber.ROUND_HALF_UP
         }
@@ -300,8 +300,8 @@ describe('Amount/Index.vue', () => {
     it('shows "<" when rounding does not cross the threshold', async () => {
       const component = await mountSuspended(Index, {
         props: {
-          amount: '0.49',
           decimals: 0,
+          amount: '0.49',
           shouldAbbreviate: false,
           roundingMode: BigNumber.ROUND_HALF_UP
         }
@@ -315,8 +315,8 @@ describe('Amount/Index.vue', () => {
     it('shows rounded value when ROUND_UP crosses decimal threshold', async () => {
       const component = await mountSuspended(Index, {
         props: {
-          amount: '0.001',
           decimals: 2,
+          amount: '0.001',
           roundingMode: BigNumber.ROUND_UP
         }
       })
@@ -329,8 +329,8 @@ describe('Amount/Index.vue', () => {
     it('no trailing zeros with custom decimals', async () => {
       const component = await mountSuspended(Index, {
         props: {
-          amount: '1.5',
           decimals: 4,
+          amount: '1.5',
           noTrailingZeros: true
         }
       })


### PR DESCRIPTION
Fixed a bug where the Amount component was showing "<1" even when rounding the value would actually push it above the threshold. Like `0.99` with 0 decimals and `ROUND_HALF_UP` was displaying "<1" instead of just "1".
The issue was that we were checking if the raw amount was below the decimal threshold but never actually applying the rounding mode first, so now we round first and only show the "less than" prefix if the rounded value is still at or below zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Small-number display now rounds values using the configured decimals and rounding mode before deciding whether to show the “<1” marker; also treats non-positive amounts and when subscript mode is enabled as not showing the marker.

* **Tests**
  * Added test coverage for various rounding modes and their interaction with small-number formatting, including positive and negative edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->