### PR TITLE
fix: broadcast autosign rejects all unauthorised messages

### DIFF
--- a/app/composables/hooks/onBroadcastResponse.ts
+++ b/app/composables/hooks/onBroadcastResponse.ts
@@ -1,0 +1,6 @@
+import { EventBus } from '../../types'
+import type { TxResponse } from '@injectivelabs/sdk-ts'
+
+export const onBroadcastResponse = (callback: (response: TxResponse) => void) => {
+  useEventBus(EventBus.BroadcastResponse).on((response) => callback(response as TxResponse))
+}

--- a/app/composables/index.ts
+++ b/app/composables/index.ts
@@ -1,4 +1,15 @@
-import { onWalletDisconnected } from "./hooks/onWalletDisconnected";
-import { onWalletConnected, onHasMagicAccount, onWalletInitialConnected } from "./hooks/onWalletConnected";
+import { onBroadcastResponse } from './hooks/onBroadcastResponse'
+import { onWalletDisconnected } from './hooks/onWalletDisconnected'
+import {
+  onWalletConnected,
+  onHasMagicAccount,
+  onWalletInitialConnected
+} from './hooks/onWalletConnected'
 
-export { onWalletConnected, onHasMagicAccount, onWalletDisconnected, onWalletInitialConnected }
+export {
+  onWalletConnected,
+  onHasMagicAccount,
+  onBroadcastResponse,
+  onWalletDisconnected,
+  onWalletInitialConnected
+}

--- a/app/store/wallet/index.ts
+++ b/app/store/wallet/index.ts
@@ -762,7 +762,8 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
         (walletStore.autoSign.expiration || 0) > nowInSeconds
 
       if (isAutoSignActive && !walletStore.isGoogleAuth) {
-        const isUnauthorizedMessages = checkUnauthorizedMessages(normalizedMessages)
+        const isUnauthorizedMessages =
+          checkUnauthorizedMessages(normalizedMessages)
 
         if (!isUnauthorizedMessages) {
           const autoSign = walletStore.autoSign as AutoSign
@@ -777,14 +778,12 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
             injectiveAddress: autoSign.injectiveAddress
           }
 
-          const response = await withAutoSignPrivateKey(
-            autoSign,
-            async () =>
-              walletStore.isFeeDelegationEnabled
-                ? await autoSignMsgBroadcaster.broadcastWithFeeDelegation(
-                    autoSignOptions
-                  )
-                : await autoSignMsgBroadcaster.broadcastV2(autoSignOptions)
+          const response = await withAutoSignPrivateKey(autoSign, async () =>
+            walletStore.isFeeDelegationEnabled
+              ? await autoSignMsgBroadcaster.broadcastWithFeeDelegation(
+                  autoSignOptions
+                )
+              : await autoSignMsgBroadcaster.broadcastV2(autoSignOptions)
           )
 
           useEventBus(EventBus.BroadcastResponse).emit(response)
@@ -968,26 +967,26 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       // Extract contract grant targets directly — getAutoSignGrantConfig is not
       // used here because it throws when all three inputs are empty, which is a
       // valid scenario when only existingGrants is provided.
-      const contractAddress = Object.keys(contractMsgTypeMap || {})[0] as
-        | string
-        | undefined
-      const contractMsgsType: string[] =
-        Object.values(contractMsgTypeMap || {})[0] || []
+      const contractEntries = Object.entries(contractMsgTypeMap || {}).map(
+        ([contractAddress, contractMsgsType]) => ({ contractAddress, contractMsgsType })
+      )
 
-      const hasMissingOrExpiringContractAuthz =
-        contractAddress && contractMsgsType.length > 0
-          ? hasMissingOrExpiringGrants({
-              grants,
-              messageTypes: contractMsgsType,
-              grantee: contractAddress,
-              granter: walletStore.injectiveAddress
-            })
-          : false
+      const hasMissingOrExpiringContractAuthz = contractEntries.some(
+        ({ contractAddress, contractMsgsType }) =>
+          contractMsgsType.length > 0 &&
+          hasMissingOrExpiringGrants({
+            grants,
+            messageTypes: contractMsgsType,
+            grantee: contractAddress,
+            granter: walletStore.injectiveAddress
+          })
+      )
 
       if (
         hasValidAutoSignExpiration &&
         !hasMissingOrExpiringAuthz &&
-        !hasMissingOrExpiringContractAuthz
+        !hasMissingOrExpiringContractAuthz &&
+        contractExecutionCompatAuthz.length === 0
       ) {
         return
       }
@@ -1011,22 +1010,27 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
         grantee: autoSign.injectiveAddress,
         granter: walletStore.injectiveAddress
       })
-      const contractMsgs =
-        contractAddress && contractMsgsType.length > 0
-          ? getMissingGrantMessages({
-              grants,
-              messageTypes: contractMsgsType,
-              expiryInSeconds,
-              grantee: contractAddress,
-              granter: walletStore.injectiveAddress
-            })
-          : []
-      const messages = [...authZMsgs, ...contractMsgs, ...grantWithAuthorization]
+      const contractMsgs = contractEntries.flatMap(
+        ({ contractAddress, contractMsgsType }) =>
+          contractMsgsType.length > 0
+            ? getMissingGrantMessages({
+                grants,
+                messageTypes: contractMsgsType,
+                expiryInSeconds,
+                grantee: contractAddress,
+                granter: walletStore.injectiveAddress
+              })
+            : []
+      )
+      const messages = [
+        ...authZMsgs,
+        ...contractMsgs,
+        ...grantWithAuthorization
+      ]
       const expiration = getAutoSignGrantExpiration({
         grants,
         messageTypes: msgsType,
-        contractMessageTypes: contractMsgsType,
-        contractGrantee: contractAddress,
+        contractEntries,
         granter: walletStore.injectiveAddress,
         renewedExpiration: messages.length > 0 ? renewedExpiration : undefined,
         grantee: autoSign.injectiveAddress
@@ -1099,7 +1103,7 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
 
       const actualAutoSign = { ...autoSign } as AutoSign
 
-      const { contractAddress, contractMsgsType } = getAutoSignGrantConfig({
+      const { contractEntries } = getAutoSignGrantConfig({
         msgsType,
         contractMsgTypeMap,
         contractExecutionCompatAuthz
@@ -1128,13 +1132,16 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
         expiryInSeconds: duration,
         granter: walletStore.injectiveAddress
       })
-      const contractMsgs = getMissingGrantMessages({
-        grants,
-        grantee: contractAddress,
-        messageTypes: contractMsgsType,
-        expiryInSeconds: duration,
-        granter: walletStore.injectiveAddress
-      })
+      const contractMsgs = contractEntries.flatMap(
+        ({ contractAddress, contractMsgsType }) =>
+          getMissingGrantMessages({
+            grants,
+            grantee: contractAddress,
+            messageTypes: contractMsgsType,
+            expiryInSeconds: duration,
+            granter: walletStore.injectiveAddress
+          })
+      )
       const messages = [
         ...authZMsgs,
         ...contractMsgs,
@@ -1147,8 +1154,7 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
           granter: walletStore.injectiveAddress,
           grantee: actualAutoSign.injectiveAddress,
           messageTypes: msgsType || [],
-          contractGrantee: contractAddress,
-          contractMessageTypes: contractMsgsType
+          contractEntries
         })
 
         return {
@@ -1167,9 +1173,8 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
           granter: walletStore.injectiveAddress,
           grantee: actualAutoSign.injectiveAddress,
           messageTypes: msgsType || [],
-          contractGrantee: contractAddress,
-          renewedExpiration: expiration,
-          contractMessageTypes: contractMsgsType
+          contractEntries,
+          renewedExpiration: expiration
         })
 
         return {
@@ -1226,7 +1231,7 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
         throw new GeneralException(new Error('Auto sign is not connected'))
       }
 
-      const { contractAddress, contractMsgsType } = getAutoSignGrantConfig({
+      const { contractEntries } = getAutoSignGrantConfig({
         msgsType,
         contractMsgTypeMap,
         contractExecutionCompatAuthz
@@ -1254,18 +1259,17 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
         })
       )
 
-      const contractMsgs =
-        contractAddress && contractMsgsType.length
-          ? contractMsgsType.map((messageType) =>
-              MsgGrant.fromJSON({
-                grantee: contractAddress,
-                granter: walletStore.injectiveAddress,
-                expiration: nowInSeconds + expirationInSeconds,
-                authorization:
-                  getGenericAuthorizationFromMessageType(messageType)
-              })
-            )
-          : []
+      const contractMsgs = contractEntries.flatMap(
+        ({ contractAddress, contractMsgsType }) =>
+          contractMsgsType.map((messageType) =>
+            MsgGrant.fromJSON({
+              grantee: contractAddress,
+              granter: walletStore.injectiveAddress,
+              expiration: nowInSeconds + expirationInSeconds,
+              authorization: getGenericAuthorizationFromMessageType(messageType)
+            })
+          )
+      )
 
       // we have to submit this transaction from the main wallet
       await this.broadcastFromMainWallet([

--- a/app/store/wallet/index.ts
+++ b/app/store/wallet/index.ts
@@ -745,15 +745,48 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       }
 
       const normalizedMessages = normalizeBroadcastMessages(messages)
-      const actualMessages =
-        walletStore.isAuthzWalletConnected || walletStore.isAutoSignEnabled
-          ? msgsOrMsgExecMsgs(
-              normalizedMessages,
-              walletStore.isAutoSignEnabled
-                ? walletStore.autoSign?.injectiveAddress
-                : walletStore.injectiveAddress
-            )
-          : normalizedMessages
+
+      // Check authorization on RAW messages BEFORE MsgExec wrapping.
+      // Authorized (all trading msgs) → wrap in MsgExec + dispatch to autoSign broadcaster directly.
+      // Unauthorized (CW20, mixed, non-trading) → fall through to main wallet with raw messages.
+      const isAutoSignActive = walletStore.autoSign && walletStore.isAutoSignEnabled
+
+      if (isAutoSignActive && !walletStore.isGoogleAuth) {
+        const isUnauthorizedMessages = checkUnauthorizedMessages(normalizedMessages)
+
+        if (!isUnauthorizedMessages) {
+          const autoSign = walletStore.autoSign as AutoSign
+          const autoSignMsgBroadcaster = await getAutoSignMsgBroadcaster()
+          const autoSignMessages = msgsOrMsgExecMsgs(
+            normalizedMessages,
+            autoSign.injectiveAddress
+          )
+          const autoSignOptions = {
+            memo,
+            msgs: autoSignMessages,
+            injectiveAddress: autoSign.injectiveAddress
+          }
+
+          const response = await withAutoSignPrivateKey(
+            autoSign,
+            async () =>
+              walletStore.isFeeDelegationEnabled
+                ? await autoSignMsgBroadcaster.broadcastWithFeeDelegation(
+                    autoSignOptions
+                  )
+                : await autoSignMsgBroadcaster.broadcastV2(autoSignOptions)
+          )
+
+          useEventBus(EventBus.BroadcastResponse).emit(response)
+
+          return response
+        }
+      }
+
+      // AuthZ or regular path (autoSign not active, or messages unauthorized for autoSign)
+      const actualMessages = walletStore.isAuthzWalletConnected
+        ? msgsOrMsgExecMsgs(normalizedMessages, walletStore.injectiveAddress)
+        : normalizedMessages
 
       const broadcastOptions = {
         memo,
@@ -761,12 +794,6 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
         injectiveAddress: walletStore.isAuthzWalletConnected
           ? walletStore.authZOrInjectiveAddress
           : walletStore.injectiveAddress
-      }
-
-      if (walletStore.isAutoSignEnabled && walletStore.isAuthzWalletConnected) {
-        throw new GeneralException(
-          new Error('Authz and auto-sign cannot be used together')
-        )
       }
 
       if (walletStore.isFeeDelegationEnabled) {
@@ -792,38 +819,37 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       const isAutoSignEnabled =
         walletStore.autoSign && walletStore.isAutoSignEnabled
 
-      if (!isAutoSignEnabled || walletStore.isGoogleAuth) {
-        const msgBroadcaster = await getMsgBroadcaster()
-
-        const response = await msgBroadcaster.broadcastV2(broadcastOptions)
-
-        useEventBus(EventBus.BroadcastResponse).emit(response)
-
-        return response
-      }
-
-      const isUnauthorizedMessages = checkUnauthorizedMessages(
-        normalizeBroadcastMessages(broadcastOptions.msgs)
-      )
-
-      if (isUnauthorizedMessages) {
-        throw new GeneralException(
-          new Error('Broadcasting is not available for auto sign for some of the included messages in the transaction')
+      if (isAutoSignEnabled && !walletStore.isGoogleAuth) {
+        const isUnauthorizedMessages = checkUnauthorizedMessages(
+          normalizeBroadcastMessages(broadcastOptions.msgs)
         )
+
+        if (!isUnauthorizedMessages) {
+          const autoSignMsgBroadcaster = await getAutoSignMsgBroadcaster()
+          const autoSign = walletStore.autoSign as AutoSign
+
+          const response = await withAutoSignPrivateKey(
+            autoSign,
+            async () =>
+              await autoSignMsgBroadcaster.broadcastV2({
+                memo: broadcastOptions.memo,
+                msgs: msgsOrMsgExecMsgs(
+                  normalizeBroadcastMessages(broadcastOptions.msgs),
+                  autoSign.injectiveAddress
+                ),
+                injectiveAddress: autoSign.injectiveAddress
+              })
+          )
+
+          useEventBus(EventBus.BroadcastResponse).emit(response)
+
+          return response
+        }
       }
 
-      const autoSignMsgBroadcaster = await getAutoSignMsgBroadcaster()
-      const autoSign = walletStore.autoSign as AutoSign
+      const msgBroadcaster = await getMsgBroadcaster()
 
-      const response = await withAutoSignPrivateKey(
-        autoSign,
-        async () =>
-          await autoSignMsgBroadcaster.broadcastV2({
-            memo: broadcastOptions.memo,
-            msgs: broadcastOptions.msgs,
-            injectiveAddress: autoSign.injectiveAddress
-          })
-      )
+      const response = await msgBroadcaster.broadcastV2(broadcastOptions)
 
       useEventBus(EventBus.BroadcastResponse).emit(response)
 
@@ -846,39 +872,38 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       const isAutoSignEnabled =
         walletStore.autoSign && walletStore.isAutoSignEnabled
 
-      if (!isAutoSignEnabled || walletStore.isGoogleAuth) {
-        const msgBroadcaster = await getMsgBroadcaster()
-
-        const response =
-          await msgBroadcaster.broadcastWithFeeDelegation(broadcastOptions)
-
-        useEventBus(EventBus.BroadcastResponse).emit(response)
-
-        return response
-      }
-
-      const isUnauthorizedMessages = checkUnauthorizedMessages(
-        normalizeBroadcastMessages(broadcastOptions.msgs)
-      )
-
-      if (isUnauthorizedMessages) {
-        throw new GeneralException(
-          new Error('Broadcasting is not available for auto sign')
+      if (isAutoSignEnabled && !walletStore.isGoogleAuth) {
+        const isUnauthorizedMessages = checkUnauthorizedMessages(
+          normalizeBroadcastMessages(broadcastOptions.msgs)
         )
+
+        if (!isUnauthorizedMessages) {
+          const autoSignMsgBroadcaster = await getAutoSignMsgBroadcaster()
+          const autoSign = walletStore.autoSign as AutoSign
+
+          const response = await withAutoSignPrivateKey(
+            autoSign,
+            async () =>
+              await autoSignMsgBroadcaster.broadcastWithFeeDelegation({
+                memo: broadcastOptions.memo,
+                msgs: msgsOrMsgExecMsgs(
+                  normalizeBroadcastMessages(broadcastOptions.msgs),
+                  autoSign.injectiveAddress
+                ),
+                injectiveAddress: autoSign.injectiveAddress
+              })
+          )
+
+          useEventBus(EventBus.BroadcastResponse).emit(response)
+
+          return response
+        }
       }
 
-      const autoSignMsgBroadcaster = await getAutoSignMsgBroadcaster()
-      const autoSign = walletStore.autoSign as AutoSign
+      const msgBroadcaster = await getMsgBroadcaster()
 
-      const response = await withAutoSignPrivateKey(
-        autoSign,
-        async () =>
-          await autoSignMsgBroadcaster.broadcastWithFeeDelegation({
-            memo: broadcastOptions.memo,
-            msgs: broadcastOptions.msgs,
-            injectiveAddress: autoSign.injectiveAddress
-          })
-      )
+      const response =
+        await msgBroadcaster.broadcastWithFeeDelegation(broadcastOptions)
 
       useEventBus(EventBus.BroadcastResponse).emit(response)
 

--- a/app/store/wallet/index.ts
+++ b/app/store/wallet/index.ts
@@ -163,7 +163,7 @@ const initialStateFactory = (): WalletStoreState => ({
     address: '',
     injectiveAddress: '',
     defaultSubaccountId: '',
-    direction: GrantDirection.Grantee
+    direction: GrantDirection.Granter
   }
 })
 
@@ -221,6 +221,12 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       }
 
       if (!state.autoSign.expiration || !state.autoSign.duration) {
+        return false
+      }
+
+      const nowInSeconds = Math.floor(Date.now() / 1000)
+
+      if (state.autoSign.expiration <= nowInSeconds) {
         return false
       }
 
@@ -694,7 +700,7 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       const walletStore = useSharedWalletStore()
 
       if (!walletStore.isUserConnected) {
-        return
+        throw new GeneralException(new Error('Wallet is not connected'))
       }
 
       const actualMessages = normalizeBroadcastMessages(messages)
@@ -735,7 +741,7 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       const walletStore = useSharedWalletStore()
 
       if (!walletStore.isUserConnected) {
-        return
+        throw new GeneralException(new Error('Wallet is not connected'))
       }
 
       if (walletStore.isAutoSignEnabled && walletStore.isAuthzWalletConnected) {
@@ -749,7 +755,11 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       // Check authorization on RAW messages BEFORE MsgExec wrapping.
       // Authorized (all trading msgs) → wrap in MsgExec + dispatch to autoSign broadcaster directly.
       // Unauthorized (CW20, mixed, non-trading) → fall through to main wallet with raw messages.
-      const isAutoSignActive = walletStore.autoSign && walletStore.isAutoSignEnabled
+      const nowInSeconds = Math.floor(Date.now() / 1000)
+      const isAutoSignActive =
+        walletStore.autoSign &&
+        walletStore.isAutoSignEnabled &&
+        (walletStore.autoSign.expiration || 0) > nowInSeconds
 
       if (isAutoSignActive && !walletStore.isGoogleAuth) {
         const isUnauthorizedMessages = checkUnauthorizedMessages(normalizedMessages)
@@ -791,9 +801,7 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       const broadcastOptions = {
         memo,
         msgs: actualMessages,
-        injectiveAddress: walletStore.isAuthzWalletConnected
-          ? walletStore.authZOrInjectiveAddress
-          : walletStore.injectiveAddress
+        injectiveAddress: walletStore.injectiveAddress
       }
 
       if (walletStore.isFeeDelegationEnabled) {
@@ -817,7 +825,9 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       }
 
       const isAutoSignEnabled =
-        walletStore.autoSign && walletStore.isAutoSignEnabled
+        walletStore.autoSign &&
+        walletStore.isAutoSignEnabled &&
+        (walletStore.autoSign.expiration || 0) > Math.floor(Date.now() / 1000)
 
       if (isAutoSignEnabled && !walletStore.isGoogleAuth) {
         const isUnauthorizedMessages = checkUnauthorizedMessages(
@@ -870,7 +880,9 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       }
 
       const isAutoSignEnabled =
-        walletStore.autoSign && walletStore.isAutoSignEnabled
+        walletStore.autoSign &&
+        walletStore.isAutoSignEnabled &&
+        (walletStore.autoSign.expiration || 0) > Math.floor(Date.now() / 1000)
 
       if (isAutoSignEnabled && !walletStore.isGoogleAuth) {
         const isUnauthorizedMessages = checkUnauthorizedMessages(
@@ -912,10 +924,12 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
 
     async validateAutoSign({
       msgsType = [],
+      contractMsgTypeMap,
       existingGrants = [],
       contractExecutionCompatAuthz = []
     }: {
       msgsType: string[]
+      contractMsgTypeMap?: Record<string, string[]>
       existingGrants: GrantAuthorizationWithDecodedAuthorization[]
       contractExecutionCompatAuthz: ContractExecutionCompatAuthz[]
     }) {
@@ -951,10 +965,29 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
         granter: walletStore.injectiveAddress
       })
 
+      // Extract contract grant targets directly — getAutoSignGrantConfig is not
+      // used here because it throws when all three inputs are empty, which is a
+      // valid scenario when only existingGrants is provided.
+      const contractAddress = Object.keys(contractMsgTypeMap || {})[0] as
+        | string
+        | undefined
+      const contractMsgsType: string[] =
+        Object.values(contractMsgTypeMap || {})[0] || []
+
+      const hasMissingOrExpiringContractAuthz =
+        contractAddress && contractMsgsType.length > 0
+          ? hasMissingOrExpiringGrants({
+              grants,
+              messageTypes: contractMsgsType,
+              grantee: contractAddress,
+              granter: walletStore.injectiveAddress
+            })
+          : false
+
       if (
         hasValidAutoSignExpiration &&
         !hasMissingOrExpiringAuthz &&
-        contractExecutionCompatAuthz.length === 0
+        !hasMissingOrExpiringContractAuthz
       ) {
         return
       }
@@ -962,7 +995,7 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
       const expiryInSeconds = autoSign.duration || AUTO_SIGN_GRANT_DURATION
       const renewedExpiration = nowInSeconds + expiryInSeconds
 
-      const grantWithAuthorization = contractExecutionCompatAuthz.map(
+      const grantWithAuthorization = (contractExecutionCompatAuthz || []).map(
         (authorization) =>
           MsgGrantWithAuthorization.fromJSON({
             authorization,
@@ -978,10 +1011,22 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
         grantee: autoSign.injectiveAddress,
         granter: walletStore.injectiveAddress
       })
-      const messages = [...authZMsgs, ...grantWithAuthorization]
+      const contractMsgs =
+        contractAddress && contractMsgsType.length > 0
+          ? getMissingGrantMessages({
+              grants,
+              messageTypes: contractMsgsType,
+              expiryInSeconds,
+              grantee: contractAddress,
+              granter: walletStore.injectiveAddress
+            })
+          : []
+      const messages = [...authZMsgs, ...contractMsgs, ...grantWithAuthorization]
       const expiration = getAutoSignGrantExpiration({
         grants,
         messageTypes: msgsType,
+        contractMessageTypes: contractMsgsType,
+        contractGrantee: contractAddress,
         granter: walletStore.injectiveAddress,
         renewedExpiration: messages.length > 0 ? renewedExpiration : undefined,
         grantee: autoSign.injectiveAddress
@@ -999,8 +1044,6 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
 
         return actualAutoSign
       }
-
-      await walletStore.connectWallet(walletStore.wallet)
 
       // we have to submit this transaction from the main wallet
       await this.broadcastFromMainWallet(messages)

--- a/app/wallet/utils/authz.ts
+++ b/app/wallet/utils/authz.ts
@@ -123,17 +123,28 @@ function getAutoSignGrantExpiration({
   granter,
   messageTypes,
   renewedExpiration,
-  contractMessageTypes,
-  contractGrantee
+  contractEntries
 }: {
   granter: string
   grantee: string
   messageTypes: string[]
-  contractGrantee?: string
   renewedExpiration?: number
-  contractMessageTypes?: string[]
   grants: GrantAuthorizationWithDecodedAuthorization[]
+  contractEntries?: Array<{
+    contractAddress: string
+    contractMsgsType: string[]
+  }>
 }) {
+  const contractExpirations = (contractEntries || []).flatMap(
+    ({ contractAddress, contractMsgsType }) =>
+      getExistingGrantExpirations({
+        grants,
+        granter,
+        grantee: contractAddress,
+        messageTypes: contractMsgsType
+      })
+  )
+
   const expirations = [
     ...getExistingGrantExpirations({
       grants,
@@ -141,12 +152,7 @@ function getAutoSignGrantExpiration({
       grantee,
       messageTypes
     }),
-    ...getExistingGrantExpirations({
-      grants,
-      granter,
-      grantee: contractGrantee,
-      messageTypes: contractMessageTypes || []
-    })
+    ...contractExpirations
   ]
 
   if (renewedExpiration) {
@@ -175,17 +181,20 @@ function getAutoSignGrantConfig({
     throw new GeneralException(new Error('No messages provided'))
   }
 
-  const contractAddress = Object.keys(contractMsgTypeMap || {})?.[0]
-  const contractMsgsType = Object.values(contractMsgTypeMap || {})[0] || []
+  const contractEntries = Object.entries(contractMsgTypeMap || {}).map(
+    ([contractAddress, contractMsgsType]) => ({
+      contractAddress,
+      contractMsgsType
+    })
+  )
 
-  if (contractAddress && !isCw20ContractAddress(contractAddress)) {
-    throw new GeneralException(new Error('Invalid contract addresses'))
+  for (const { contractAddress } of contractEntries) {
+    if (!isCw20ContractAddress(contractAddress)) {
+      throw new GeneralException(new Error('Invalid contract addresses'))
+    }
   }
 
-  return {
-    contractAddress,
-    contractMsgsType
-  }
+  return { contractEntries }
 }
 
 function hasMissingOrExpiringGrants({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved routing so AuthZ and auto-sign work together (including fee-delegation when applicable).
  * Added a broadcast-response hook for reacting to transaction results.
  * Auto-sign now supports multiple contract-specific grant types.

* **Bug Fixes**
  * Unauthorized auto-sign messages now fall back to the standard broadcast/AuthZ flow.
  * Auto-sign expiration detection fixed (expired = disabled).
  * Broadcasting returns a clear "Wallet is not connected" error when disconnected.

* **Refactor**
  * Export re-exports/formats cleaned up.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InjectiveLabs/injective-ui/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->