### PR TITLE
fix(explorer): parse RFQ messages for migrated contract

### DIFF
--- a/app/data/wasmContracts.ts
+++ b/app/data/wasmContracts.ts
@@ -11,7 +11,8 @@ export enum TestnetWasmContractAddress {
 }
 
 export enum MainnetWasmContractAddress {
-  Rfq = 'inj1e0u9nl50gzhmrmhwx3v9vf535vkhwzpwku6mtk',
+  Rfq = 'inj12stwq95jet57edcu4a65r48r46s9rzrs938n8k',
+  RfqLegacy = 'inj1e0u9nl50gzhmrmhwx3v9vf535vkhwzpwku6mtk',
   MitoSwap = 'inj1j5mr2hmv7y2z7trazganj75u8km8jvdfuxncsp',
   HelixSwap = 'inj12yj3mtjarujkhcp6lg3klxjjfrx2v7v8yswgp9'
 }
@@ -31,3 +32,7 @@ export const rfqContractAddress = IS_MAINNET
   : IS_TESTNET
     ? TestnetWasmContractAddress.Rfq
     : DevnetWasmContractAddress.Rfq
+
+export const rfqContractAddresses = IS_MAINNET
+  ? [MainnetWasmContractAddress.Rfq, MainnetWasmContractAddress.RfqLegacy]
+  : [rfqContractAddress]

--- a/app/transformer/explorer/contractSummary.ts
+++ b/app/transformer/explorer/contractSummary.ts
@@ -1,6 +1,6 @@
 import { toBigNumber } from '@injectivelabs/utils'
 import {
-  rfqContractAddress,
+  rfqContractAddresses,
   mitoSwapContractAddress,
   helixSwapContractAddress
 } from './../../data/wasmContracts'
@@ -129,13 +129,19 @@ const swapConfig = (copy: string): ContractSummaryConfig => ({
   msgLabel: { label: 'Swap', msgAction: MSG_ACTION.SWAP_MIN_OUTPUT }
 })
 
+const rfqConfig: ContractSummaryConfig = {
+  copy: 'RFQ',
+  summaryFn: generateRfqSummary,
+  msgLabel: { label: 'Create RFQ Trade', msgAction: MSG_ACTION.ACCEPT_QUOTE }
+}
+
+const rfqRegistry = Object.fromEntries(
+  rfqContractAddresses.map((addr) => [addr, rfqConfig])
+) as Record<string, ContractSummaryConfig>
+
 export const contractRegistry: Record<string, ContractSummaryConfig> = {
   [helixSwapContractAddress]: swapConfig('Helix Swap'),
-  [rfqContractAddress]: {
-    copy: 'RFQ',
-    summaryFn: generateRfqSummary,
-    msgLabel: { label: 'Create RFQ Trade', msgAction: MSG_ACTION.ACCEPT_QUOTE }
-  },
+  ...rfqRegistry,
   // mitoSwapContractAddress is undefined on devnet — no devnet deployment exists
   ...(mitoSwapContractAddress && {
     [mitoSwapContractAddress]: swapConfig('Mito Swap')


### PR DESCRIPTION
Summary:
- update the mainnet RFQ parser contract to the migrated address inj12stwq95jet57edcu4a65r48r46s9rzrs938n8k
- keep the previous mainnet RFQ contract registered so historical RFQ transactions still render with RFQ summaries
- apply the RFQ message label/summary config to every registered RFQ contract address

Explorer impact:
- injective-explorer extends github:InjectiveLabs/injective-ui#master, so this fixes the RFQ-specific parsing consumed by explorer once merged.

Verification:
- git diff --check
- inspected injective-explorer and confirmed RFQ parsing is delegated to the shared injective-ui layer
- pnpm typecheck could not run in the temp clone because node_modules is not installed (nuxi missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for legacy RFQ contract address alongside the current address.

* **Updates**
  * Updated RFQ contract address to reflect the latest deployment.
  * Enhanced contract configuration to handle multiple RFQ contract addresses across different network environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->