### PR TITLE
feat/tc-layer+fix-cosmos-wallet-broadcast

### DIFF
--- a/app/store/wallet/index.spec.ts
+++ b/app/store/wallet/index.spec.ts
@@ -13,10 +13,21 @@ const walletMocks = vi.hoisted(() => ({
   validateCosmosWallet: vi.fn(),
   getAutoSignWalletStrategy: vi.fn(),
   getAutoSignMsgBroadcaster: vi.fn(),
+  getAutoSignMsgBroadcasterWithDirectSign: vi.fn(),
   confirmCosmosWalletAddress: vi.fn()
 }))
 
 vi.mock('@shared/wallet', () => walletMocks)
+
+const autoSignMocks = vi.hoisted(() => ({
+  clearAutoSignKey: vi.fn(),
+  getAutoSignPayload: vi.fn(),
+  deriveAndStoreAutoSignKey: vi.fn(),
+  withAutoSignPrivateKey: vi.fn(),
+  withAutoSignPrivateKeyWithDirectSign: vi.fn()
+}))
+
+vi.mock('../../wallet/autosign', () => autoSignMocks)
 
 vi.mock('../../service', () => ({
   getAuthZApi: vi.fn(),
@@ -33,6 +44,12 @@ describe('store/wallet validation', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    autoSignMocks.withAutoSignPrivateKey.mockImplementation(
+      async (_autoSign, callback) => await callback('private-key')
+    )
+    autoSignMocks.withAutoSignPrivateKeyWithDirectSign.mockImplementation(
+      async (_autoSign, callback) => await callback('private-key')
+    )
   })
 
   afterEach(() => {
@@ -125,7 +142,110 @@ describe('store/wallet validation', () => {
     })
     expect(actualResponse).toBe(response)
   })
+
+  it('uses direct signing for auto-sign fee delegation broadcasts', async () => {
+    const response = { txHash: '0xautosign-feegrant' }
+    const broadcastWithFeeDelegation = vi.fn().mockResolvedValue(response)
+
+    walletMocks.getAutoSignMsgBroadcasterWithDirectSign.mockResolvedValue({
+      broadcastWithFeeDelegation
+    })
+    vi.stubGlobal('useEventBus', () => ({ emit: vi.fn() }))
+
+    const walletStore = useSharedWalletStore()
+    const message = createTradingMessage()
+
+    setConnectedMainWallet(walletStore)
+    enableAutoSign(walletStore)
+    walletStore.$patch({ isFeeDelegationEnabled: true })
+
+    const actualResponse = await walletStore.broadcast(message, 'memo')
+
+    expect(walletMocks.getAutoSignMsgBroadcaster).not.toHaveBeenCalled()
+    expect(walletMocks.getAutoSignMsgBroadcasterWithDirectSign).toHaveBeenCalled()
+    expect(autoSignMocks.withAutoSignPrivateKey).not.toHaveBeenCalled()
+    expect(autoSignMocks.withAutoSignPrivateKeyWithDirectSign).toHaveBeenCalled()
+    expect(broadcastWithFeeDelegation).toHaveBeenCalledWith({
+      memo: 'memo',
+      injectiveAddress: autoSignInjectiveAddress,
+      msgs: expect.any(Array)
+    })
+    expect(actualResponse).toBe(response)
+  })
+
+  it('keeps regular auto-sign broadcasts on the non-direct broadcaster', async () => {
+    const response = { txHash: '0xautosign' }
+    const broadcastV2 = vi.fn().mockResolvedValue(response)
+
+    walletMocks.getAutoSignMsgBroadcaster.mockResolvedValue({
+      broadcastV2
+    })
+    vi.stubGlobal('useEventBus', () => ({ emit: vi.fn() }))
+
+    const walletStore = useSharedWalletStore()
+    const message = createTradingMessage()
+
+    setConnectedMainWallet(walletStore)
+    enableAutoSign(walletStore)
+    walletStore.$patch({ isFeeDelegationEnabled: false })
+
+    const actualResponse = await walletStore.broadcast(message, 'memo')
+
+    expect(walletMocks.getAutoSignMsgBroadcaster).toHaveBeenCalled()
+    expect(walletMocks.getAutoSignMsgBroadcasterWithDirectSign).not.toHaveBeenCalled()
+    expect(autoSignMocks.withAutoSignPrivateKey).toHaveBeenCalled()
+    expect(autoSignMocks.withAutoSignPrivateKeyWithDirectSign).not.toHaveBeenCalled()
+    expect(broadcastV2).toHaveBeenCalledWith({
+      memo: 'memo',
+      injectiveAddress: autoSignInjectiveAddress,
+      msgs: expect.any(Array)
+    })
+    expect(actualResponse).toBe(response)
+  })
+
+  it('uses direct signing for explicit auto-sign fee delegation helper broadcasts', async () => {
+    const response = { txHash: '0xexplicit-feegrant' }
+    const broadcastWithFeeDelegation = vi.fn().mockResolvedValue(response)
+
+    walletMocks.getAutoSignMsgBroadcasterWithDirectSign.mockResolvedValue({
+      broadcastWithFeeDelegation
+    })
+    vi.stubGlobal('useEventBus', () => ({ emit: vi.fn() }))
+
+    const walletStore = useSharedWalletStore()
+    const message = createTradingMessage()
+
+    setConnectedMainWallet(walletStore)
+    enableAutoSign(walletStore)
+    walletStore.$patch({ isFeeDelegationEnabled: true })
+
+    const actualResponse = await walletStore.broadcastWithFeeDelegation({
+      memo: 'memo',
+      msgs: [message],
+      injectiveAddress
+    })
+
+    expect(walletMocks.getAutoSignMsgBroadcaster).not.toHaveBeenCalled()
+    expect(walletMocks.getAutoSignMsgBroadcasterWithDirectSign).toHaveBeenCalled()
+    expect(autoSignMocks.withAutoSignPrivateKey).not.toHaveBeenCalled()
+    expect(autoSignMocks.withAutoSignPrivateKeyWithDirectSign).toHaveBeenCalled()
+    expect(broadcastWithFeeDelegation).toHaveBeenCalledWith({
+      memo: 'memo',
+      injectiveAddress: autoSignInjectiveAddress,
+      msgs: expect.any(Array)
+    })
+    expect(actualResponse).toBe(response)
+  })
 })
+
+function createTradingMessage() {
+  return {
+    toJSON: () =>
+      JSON.stringify({
+        '@type': '/injective.exchange.v1beta1.MsgCreateDerivativeLimitOrder'
+      })
+  } as any
+}
 
 function setEvmWallet(walletStore: ReturnType<typeof useSharedWalletStore>) {
   walletStore.$patch({

--- a/app/store/wallet/index.ts
+++ b/app/store/wallet/index.ts
@@ -810,21 +810,18 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
           }
 
           const response = walletStore.isFeeDelegationEnabled
-            ? await withAutoSignPrivateKeyWithDirectSign(
-                autoSign,
-                async () => {
-                  const autoSignMsgBroadcaster =
-                    await getAutoSignMsgBroadcasterWithDirectSign()
+            ? await withAutoSignPrivateKeyWithDirectSign(autoSign, async () => {
+                const broadcaster =
+                  await getAutoSignMsgBroadcasterWithDirectSign()
 
-                  return await autoSignMsgBroadcaster.broadcastWithFeeDelegation(
-                    autoSignOptions
-                  )
-                }
-              )
+                return await broadcaster.broadcastWithFeeDelegation(
+                  autoSignOptions
+                )
+              })
             : await withAutoSignPrivateKey(autoSign, async () => {
-                const autoSignMsgBroadcaster = await getAutoSignMsgBroadcaster()
+                const broadcaster = await getAutoSignMsgBroadcaster()
 
-                return await autoSignMsgBroadcaster.broadcastV2(autoSignOptions)
+                return await broadcaster.broadcastV2(autoSignOptions)
               })
 
           useEventBus(EventBus.BroadcastResponse).emit(response)

--- a/app/store/wallet/index.ts
+++ b/app/store/wallet/index.ts
@@ -19,17 +19,18 @@ import {
   getDefaultSubaccountId
 } from '@injectivelabs/sdk-ts/utils'
 import {
-  clearAutoSignKey,
-  getAutoSignPayload,
-  withAutoSignPrivateKey,
-  deriveAndStoreAutoSignKey
-} from '../../wallet/autosign'
-import {
   MsgGrant,
   msgsOrMsgExecMsgs,
   MsgGrantWithAuthorization,
   getGenericAuthorizationFromMessageType
 } from '@injectivelabs/sdk-ts/core/modules'
+import {
+  clearAutoSignKey,
+  getAutoSignPayload,
+  withAutoSignPrivateKey,
+  deriveAndStoreAutoSignKey,
+  withAutoSignPrivateKeyWithDirectSign
+} from '../../wallet/autosign'
 import {
   getAutoSignGrantConfig,
   getMissingGrantMessages,
@@ -47,7 +48,8 @@ import {
   validateCosmosWallet,
   getAutoSignWalletStrategy,
   getAutoSignMsgBroadcaster,
-  confirmCosmosWalletAddress
+  confirmCosmosWalletAddress,
+  getAutoSignMsgBroadcasterWithDirectSign
 } from '@shared/wallet'
 import { EventBus, GrantDirection, WalletConnectStatus } from '../../types'
 import type { MsgBroadcasterTxOptions } from '@injectivelabs/wallet-core'
@@ -797,7 +799,6 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
 
         if (!isUnauthorizedMessages) {
           const autoSign = walletStore.autoSign as AutoSign
-          const autoSignMsgBroadcaster = await getAutoSignMsgBroadcaster()
           const autoSignMessages = msgsOrMsgExecMsgs(
             normalizedMessages,
             autoSign.injectiveAddress
@@ -808,13 +809,23 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
             injectiveAddress: autoSign.injectiveAddress
           }
 
-          const response = await withAutoSignPrivateKey(autoSign, async () =>
-            walletStore.isFeeDelegationEnabled
-              ? await autoSignMsgBroadcaster.broadcastWithFeeDelegation(
-                  autoSignOptions
-                )
-              : await autoSignMsgBroadcaster.broadcastV2(autoSignOptions)
-          )
+          const response = walletStore.isFeeDelegationEnabled
+            ? await withAutoSignPrivateKeyWithDirectSign(
+                autoSign,
+                async () => {
+                  const autoSignMsgBroadcaster =
+                    await getAutoSignMsgBroadcasterWithDirectSign()
+
+                  return await autoSignMsgBroadcaster.broadcastWithFeeDelegation(
+                    autoSignOptions
+                  )
+                }
+              )
+            : await withAutoSignPrivateKey(autoSign, async () => {
+                const autoSignMsgBroadcaster = await getAutoSignMsgBroadcaster()
+
+                return await autoSignMsgBroadcaster.broadcastV2(autoSignOptions)
+              })
 
           useEventBus(EventBus.BroadcastResponse).emit(response)
 
@@ -921,10 +932,11 @@ export const useSharedWalletStore = defineStore('sharedWallet', {
         )
 
         if (!isUnauthorizedMessages) {
-          const autoSignMsgBroadcaster = await getAutoSignMsgBroadcaster()
+          const autoSignMsgBroadcaster =
+            await getAutoSignMsgBroadcasterWithDirectSign()
           const autoSign = walletStore.autoSign as AutoSign
 
-          const response = await withAutoSignPrivateKey(
+          const response = await withAutoSignPrivateKeyWithDirectSign(
             autoSign,
             async () =>
               await autoSignMsgBroadcaster.broadcastWithFeeDelegation({


### PR DESCRIPTION
<img width="683" height="1036" alt="image" src="https://github.com/user-attachments/assets/02110404-e4e3-4697-ad72-eff858ccf249" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated wallet broadcasting to correctly use direct-sign variants when fee delegation is enabled, ensuring proper routing between fee delegation and standard signing paths.

## Tests
* Added comprehensive test coverage verifying that wallet broadcasts properly route through appropriate signing methods based on fee delegation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->