### PR TITLE
fix: emit spotQuantityV2 token for v2 exchange messages so quantities are not scaled twice

### DIFF
--- a/app/transformer/explorer/utils/exchange.spec.ts
+++ b/app/transformer/explorer/utils/exchange.spec.ts
@@ -1,0 +1,269 @@
+import { it, expect, describe } from 'vitest'
+import {
+  batchUpdateOrdersSummary,
+  createSpotLimitOrderSummary,
+  createSpotMarketOrderSummary,
+  batchCreateSpotLimitOrdersSummary
+} from './exchange'
+import { getHumanReadableMessage } from '../messageSummary'
+import type { Message, EventLog } from '@injectivelabs/sdk-ts'
+
+const MARKET_ID =
+  '0xa8c14f892f7f7d2516442220a05b652d5afee3f57a5495981dfadad7c99ef78e84'
+
+const buildMessage = (type: string, message: any): Message =>
+  ({ type, message }) as unknown as Message
+
+const logs: EventLog[] = []
+
+describe('exchange message summaries - v1 quantities', () => {
+  it('createSpotMarketOrderSummary emits spotQuantity token for v1', () => {
+    const summary = createSpotMarketOrderSummary({
+      logs,
+      value: buildMessage('injective.exchange.v1beta1.MsgCreateSpotMarketOrder', {
+        sender: 'inj1sender',
+        order: {
+          market_id: MARKET_ID,
+          order_info: { quantity: '59829000000000000000' },
+          order_type: 'BUY'
+        }
+      })
+    })
+
+    expect(summary[0]).toContain(
+      `{{spotQuantity:${MARKET_ID}-59829000000000000000}}`
+    )
+  })
+
+  it('createSpotLimitOrderSummary emits spotQuantity and spotPrice tokens for v1', () => {
+    const summary = createSpotLimitOrderSummary({
+      logs,
+      value: buildMessage('injective.exchange.v1beta1.MsgCreateSpotLimitOrder', {
+        sender: 'inj1sender',
+        order: {
+          market_id: MARKET_ID,
+          order_info: { quantity: '59829000000000000000', price: '5049000000' },
+          order_type: 'BUY'
+        }
+      })
+    })
+
+    expect(summary[0]).toContain(
+      `{{spotQuantity:${MARKET_ID}-59829000000000000000}}`
+    )
+    expect(summary[0]).toContain(`{{spotPrice:${MARKET_ID}-5049000000}}`)
+  })
+
+  it('batchCreateSpotLimitOrdersSummary emits spotQuantity token for v1', () => {
+    const summary = batchCreateSpotLimitOrdersSummary({
+      logs,
+      value: buildMessage(
+        'injective.exchange.v1beta1.MsgBatchCreateSpotLimitOrders',
+        {
+          sender: 'inj1sender',
+          orders: [
+            {
+              market_id: MARKET_ID,
+              order_info: {
+                quantity: '1000000000000000000',
+                price: '5049000000'
+              }
+            }
+          ]
+        }
+      )
+    })
+
+    expect(summary[1]).toContain(
+      `{{spotQuantity:${MARKET_ID}-1000000000000000000}}`
+    )
+    expect(summary[1]).toContain(`{{spotPrice:${MARKET_ID}-5049000000}}`)
+  })
+
+  it('batchUpdateOrdersSummary emits spotQuantity token for v1 spot orders', () => {
+    const summary = batchUpdateOrdersSummary({
+      logs,
+      value: buildMessage(
+        'injective.exchange.v1beta1.MsgBatchUpdateOrders',
+        {
+          sender: 'inj1sender',
+          spot_orders_to_cancel: [],
+          derivative_orders_to_cancel: [],
+          spot_orders_to_create: [
+            {
+              market_id: MARKET_ID,
+              order_info: {
+                quantity: '1000000000000000000',
+                price: '5049000000'
+              },
+              order_type: 'BUY'
+            }
+          ],
+          derivative_orders_to_create: [],
+          spot_market_ids_to_cancel_all: [],
+          derivative_market_ids_to_cancel_all: []
+        }
+      )
+    })
+
+    expect(summary[0]).toContain(
+      `{{spotQuantity:${MARKET_ID}-1000000000000000000}}`
+    )
+    expect(summary[0]).toContain(`{{spotPrice:${MARKET_ID}-5049000000}}`)
+  })
+})
+
+describe('exchange message summaries - v2 quantities', () => {
+  it('createSpotMarketOrderSummary emits spotQuantityV2 token for v2', () => {
+    const summary = createSpotMarketOrderSummary({
+      logs,
+      isV2: true,
+      value: buildMessage('injective.exchange.v2.MsgCreateSpotMarketOrder', {
+        sender: 'inj1sender',
+        order: {
+          market_id: MARKET_ID,
+          order_info: { quantity: '59.829000000000000000' },
+          order_type: 'BUY'
+        }
+      })
+    })
+
+    expect(summary[0]).toContain(
+      `{{spotQuantityV2:${MARKET_ID}-59.829000000000000000}}`
+    )
+    expect(summary[0]).not.toContain('{{spotQuantity:')
+  })
+
+  it('createSpotLimitOrderSummary emits spotQuantityV2 and spotPriceV2 tokens for v2', () => {
+    const summary = createSpotLimitOrderSummary({
+      logs,
+      isV2: true,
+      value: buildMessage('injective.exchange.v2.MsgCreateSpotLimitOrder', {
+        sender: 'inj1sender',
+        order: {
+          market_id: MARKET_ID,
+          order_info: {
+            quantity: '59.829000000000000000',
+            price: '5.049000000000000000'
+          },
+          order_type: 'BUY_PO'
+        }
+      })
+    })
+
+    expect(summary[0]).toContain(
+      `{{spotQuantityV2:${MARKET_ID}-59.829000000000000000}}`
+    )
+    expect(summary[0]).toContain(
+      `{{spotPriceV2:${MARKET_ID}-5.049000000000000000}}`
+    )
+    expect(summary[0]).not.toContain('{{spotQuantity:')
+    expect(summary[0]).not.toContain('{{spotPrice:')
+  })
+
+  it('batchCreateSpotLimitOrdersSummary emits spotQuantityV2 token for v2', () => {
+    const summary = batchCreateSpotLimitOrdersSummary({
+      logs,
+      isV2: true,
+      value: buildMessage(
+        'injective.exchange.v2.MsgBatchCreateSpotLimitOrders',
+        {
+          sender: 'inj1sender',
+          orders: [
+            {
+              market_id: MARKET_ID,
+              order_info: {
+                quantity: '1.000000000000000000',
+                price: '5.049000000000000000'
+              }
+            }
+          ]
+        }
+      )
+    })
+
+    expect(summary[1]).toContain(
+      `{{spotQuantityV2:${MARKET_ID}-1.000000000000000000}}`
+    )
+    expect(summary[1]).toContain(
+      `{{spotPriceV2:${MARKET_ID}-5.049000000000000000}}`
+    )
+  })
+
+  it('batchUpdateOrdersSummary emits v2 tokens for spot orders and keeps derivative quantity token', () => {
+    const summary = batchUpdateOrdersSummary({
+      logs,
+      isV2: true,
+      value: buildMessage('injective.exchange.v2.MsgBatchUpdateOrders', {
+        sender: 'inj1sender',
+        spot_orders_to_cancel: [],
+        derivative_orders_to_cancel: [],
+        spot_orders_to_create: [
+          {
+            market_id: MARKET_ID,
+            order_info: {
+              quantity: '1.000000000000000000',
+              price: '5.049000000000000000'
+            },
+            order_type: 'BUY'
+          }
+        ],
+        derivative_orders_to_create: [
+          {
+            market_id: MARKET_ID,
+            order_info: {
+              quantity: '0.200000000000000000',
+              price: '5.159000000000000000'
+            },
+            order_type: 'BUY'
+          }
+        ],
+        spot_market_ids_to_cancel_all: [],
+        derivative_market_ids_to_cancel_all: []
+      })
+    })
+
+    expect(summary[0]).toContain(
+      `{{derivativeQuantity:${MARKET_ID}-0.200000000000000000}}`
+    )
+    expect(summary[0]).toContain(
+      `{{derivativePriceV2:${MARKET_ID}-5.159000000000000000}}`
+    )
+    expect(summary[1]).toContain(
+      `{{spotQuantityV2:${MARKET_ID}-1.000000000000000000}}`
+    )
+    expect(summary[1]).toContain(
+      `{{spotPriceV2:${MARKET_ID}-5.049000000000000000}}`
+    )
+  })
+})
+
+describe('getHumanReadableMessage - v2 message dispatch', () => {
+  it('routes injective.exchange.v2.MsgCreateSpotLimitOrder with v2 quantity token', () => {
+    const summaries = getHumanReadableMessage({
+      logs,
+      value: buildMessage('/injective.exchange.v2.MsgCreateSpotLimitOrder', {
+        sender: 'inj1k8txa2875vzlgf8afqn3lz9gv23rv6k9we59zj',
+        order: {
+          market_id: MARKET_ID,
+          order_info: {
+            subaccount_id:
+              '0xb1d66ea8fea305f424fd48271f88a862a2366ac5000000000000000000000001',
+            fee_recipient: 'inj1k8txa2875vzlgf8afqn3lz9gv23rv6k9we59zj',
+            price: '5.049000000000000000',
+            quantity: '59.829000000000000000'
+          },
+          order_type: 'BUY_PO'
+        }
+      })
+    })
+
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0]).toContain(
+      `{{spotQuantityV2:${MARKET_ID}-59.829000000000000000}}`
+    )
+    expect(summaries[0]).toContain(
+      `{{spotPriceV2:${MARKET_ID}-5.049000000000000000}}`
+    )
+  })
+})

--- a/app/transformer/explorer/utils/exchange.ts
+++ b/app/transformer/explorer/utils/exchange.ts
@@ -10,15 +10,18 @@ export type ExchangeSummaryParams = {
 }
 
 export const createSpotMarketOrderSummary = ({
-  value
+  value,
+  isV2 = false
 }: ExchangeSummaryParams): string[] => {
   const { sender, order } = value.message
 
   const { quantity } = order.order_info
   const { market_id: marketId } = order
 
+  const spotQuantityToken = isV2 ? 'spotQuantityV2' : 'spotQuantity'
+
   return [
-    `{{account:${sender}}} created a MARKET ${order.order_type} order for {{spotQuantity:${marketId}-${quantity}}} in {{market:${marketId}}}`
+    `{{account:${sender}}} created a MARKET ${order.order_type} order for {{${spotQuantityToken}:${marketId}-${quantity}}} in {{market:${marketId}}}`
   ]
 }
 
@@ -32,9 +35,10 @@ export const createSpotLimitOrderSummary = ({
   const { market_id: marketId } = order
 
   const spotPriceToken = isV2 ? 'spotPriceV2' : 'spotPrice'
+  const spotQuantityToken = isV2 ? 'spotQuantityV2' : 'spotQuantity'
 
   return [
-    `{{account:${sender}}} created a LIMIT ${order.order_type} order for {{spotQuantity:${marketId}-${quantity}}} at {{${spotPriceToken}:${marketId}-${price}}} in {{market:${marketId}}}`
+    `{{account:${sender}}} created a LIMIT ${order.order_type} order for {{${spotQuantityToken}:${marketId}-${quantity}}} at {{${spotPriceToken}:${marketId}-${price}}} in {{market:${marketId}}}`
   ]
 }
 
@@ -140,12 +144,13 @@ export const batchCreateSpotLimitOrdersSummary = ({
   const { sender, orders } = value.message
 
   const spotPriceToken = isV2 ? 'spotPriceV2' : 'spotPrice'
+  const spotQuantityToken = isV2 ? 'spotQuantityV2' : 'spotQuantity'
 
   return [
     `{{account:${sender}}} created a batch of spot limit orders:`,
     ...orders.map(
       (order: any) =>
-        `• {{spotQuantity:${order.market_id}-${order.order_info.quantity}}} at {{${spotPriceToken}:${order.market_id}-${order.order_info.price}}} in {{market:${order.market_id}}}`
+        `• {{${spotQuantityToken}:${order.market_id}-${order.order_info.quantity}}} at {{${spotPriceToken}:${order.market_id}-${order.order_info.price}}} in {{market:${order.market_id}}}`
     )
   ]
 }
@@ -232,6 +237,7 @@ export const batchUpdateOrdersSummary = ({
 
   const derivativePriceToken = isV2 ? 'derivativePriceV2' : 'derivativePrice'
   const spotPriceToken = isV2 ? 'spotPriceV2' : 'spotPrice'
+  const spotQuantityToken = isV2 ? 'spotQuantityV2' : 'spotQuantity'
 
   const cancelAllSpotMarketIds = spotMarketIdsToCancelAll.map(
     (marketId: string) => {
@@ -256,7 +262,7 @@ export const batchUpdateOrdersSummary = ({
     const { quantity, price } = order.order_info
     const { market_id: marketId } = order
 
-    return `{{account:${sender}}} created a LIMIT ${order.order_type} order for {{spotQuantity:${marketId}-${quantity}}} at {{${spotPriceToken}:${marketId}-${price}}} in {{market:${marketId}}}`
+    return `{{account:${sender}}} created a LIMIT ${order.order_type} order for {{${spotQuantityToken}:${marketId}-${quantity}}} at {{${spotPriceToken}:${marketId}-${price}}} in {{market:${marketId}}}`
   })
 
   const spotCancelOrders = spotOrdersToCancel.map((order: any) => {


### PR DESCRIPTION
## Context

Slack report from #request-product-issue-support (Eric Chen): the block explorer (and Helix-linked trade views) show human-readable **v2** exchange message quantities scaled by 10^18 — e.g. buying 1 INJ renders as `1 × 10^-18`.

Reference tx: `3CA52C5134A1A093E04441555BC07C74D637D9B0263DA6FD70AD516245FD70DC` (MsgExec → `/injective.exchange.v2.MsgCreateSpotLimitOrder`, INJ/USDT) — `order_info` carries `quantity: "59.829"`, `price: "5.049"` already in human-readable form.

## Root cause

Chain-side (`injective-core` `types/market.go`, `keeper/utils/converter.go`):

| field | v1 message | v2 message |
|---|---|---|
| spot quantity | chain format (×10^baseDecimals) | human-readable |
| spot price | chain format (×10^quote/10^base) | human-readable |
| derivative quantity | human-readable (10^0) — no diff | human-readable |
| derivative price | chain format (×10^quoteDecimals) | human-readable |

The summary pipeline already handles v2 **prices** via versioned tokens (`spotPriceV2` / `derivativePriceV2`), which renderers skip scaling for. **Quantities never got the same treatment**: `{{spotQuantity:…}}` is emitted identically for v1 and v2 messages, so consumers (e.g. explorer `App/MsgSummary/Spot/Quantity.vue`) unconditionally divide by `10^baseToken.decimals` — dividing the already human-readable v2 value by 10^18 again.

## v2 message amount-format reference (for the upcoming FE list)

Per `proto/injective/exchange/v2/tx.proto`, v2 message amounts split into two families:

- **`LegacyDec` string fields — human-readable in v2** (need a `*V2` passthrough token when mapped):
  - order `order_info.price` / `order_info.quantity` (this PR), derivative order `margin`
  - `MsgIncreasePositionMargin` / `MsgDecreasePositionMargin` `amount` — proto doc: "(in human readable format)"
- **`cosmos.base.v1beta1.Coin` fields — still chain format in v2** (bank coins; keep the existing unconditionally-scaled `{{denom:}}`-style tokens):
  - `MsgDeposit.amount`, `MsgWithdraw.amount` — proto docs: "(in chain format)"
  - (same expected for `MsgExternalTransfer` / `MsgSubaccountTransfer` / peggy-style transfers, which move bank coins)

This is why this PR versions **per token** rather than applying a blanket "v2 message → no scaling" rule: a blanket rule would misrender v2 deposits/withdrawals. Note `MsgDepositV2` / `MsgWithdrawV2` currently have **no summary-map entries at all** (no summary is rendered for them today), so nothing needs changing for them here — but whoever adds those entries should map them to the existing v1-style handlers with chain-format scaling.

## Changes

- Emit a versioned `spotQuantityV2` token (mirroring the established `spotPriceV2` pattern) when `isV2` is set, in the 4 spot-order summary builders:
  - `createSpotMarketOrderSummary` (now also honors `isV2`; previously ignored it)
  - `createSpotLimitOrderSummary`
  - `batchCreateSpotLimitOrdersSummary`
  - `batchUpdateOrdersSummary` (spot branch)
- Derivative quantities are intentionally left unchanged: their format is identical (10^0) across v1/v2, so the existing non-scaling render path is correct for both.
- Cancel-event summaries are unaffected: the chain still emits v1beta1 chain-format events alongside v2 events (verified on the reference tx).
- Added unit tests (`exchange.spec.ts`) covering v1/v2 token emission for all four builders plus end-to-end dispatch through `getHumanReadableMessage` for `injective.exchange.v2.MsgCreateSpotLimitOrder`.

## Consumer note (follow-up PRs)

Renderers of these tokens must handle the new `spotQuantityV2` token in the same release cycle — otherwise v2 spot quantities render as nothing (unknown token type is dropped):

- `injective-explorer`: `App/MsgSummary/Index.vue` + `App/MsgSummary/Spot/Quantity.vue` (add `isV2` guard, mirror of `Spot/Price.vue`)
- `injective-hub`: identical copies of the above

Follow-ups found while investigating (not addressed here):
- `batchUpdateOrdersSummary` maps `*_market_ids_to_cancel_all` unguarded (no try/catch above it)
- V2 variants of margin/deposit/withdraw messages have no summary-map entries at all
- `injective-uis/shared/markets` transformer port has no V2 entries (all v2 messages → empty summaries)

## Verification

- `pnpm vitest run app/transformer/explorer/utils/exchange.spec.ts` → 9/9 passing
- `pnpm typecheck` → clean
- `eslint --max-warnings 0` on changed files → clean
- Full `pnpm test`: 1 pre-existing failure in `components/Amount/Usd.spec.ts` (also fails on `master`, unrelated)